### PR TITLE
feat: organization-policy now can specify policy as object (not string)

### DIFF
--- a/organizations/policy/.rpdk-config
+++ b/organizations/policy/.rpdk-config
@@ -5,7 +5,7 @@
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {
-        "useDocker": true,
+        "useDocker": false,
         "protocolVersion": "2.0.0"
     }
 }

--- a/organizations/policy/__tests__/data-policy/create-success.json
+++ b/organizations/policy/__tests__/data-policy/create-success.json
@@ -1,0 +1,14 @@
+{
+    "clientRequestToken": "9c9ff813-e56a-4690-a340-56e760897f13",
+    "desiredResourceState": {
+      "PolicyDocument": {"services":{"@@operators_allowed_for_child_policies":["@@none"],"default":{"@@operators_allowed_for_child_policies":["@@none"],"opt_out_policy":{"@@operators_allowed_for_child_policies":["@@none"],"@@assign":"optOut"}}}},
+      "Name": "AiGlobalOptOut",
+      "Description": "some description",
+      "PolicyType": "AISERVICES_OPT_OUT_POLICY",
+      "TargetIds": [ "r-abcdef" ]
+    },
+    "previousResourceState": null,
+    "awsAccountId": "123456789012",
+    "region": "us-east-1",
+    "logicalResourceIdentifier": "MyResource"
+}

--- a/organizations/policy/__tests__/data-policy/delete-success.json
+++ b/organizations/policy/__tests__/data-policy/delete-success.json
@@ -1,0 +1,14 @@
+{
+    "clientRequestToken": "4b90a7e4-b790-456b-a937-0cfdfa211dfe",
+    "desiredResourceState": {
+        "ResourceId": "9c9ff813-e56a-4690-a340-56e760897f13",
+        "PolicyDocument": {"services":{"@@operators_allowed_for_child_policies":["@@none"],"default":{"@@operators_allowed_for_child_policies":["@@none"],"opt_out_policy":{"@@operators_allowed_for_child_policies":["@@none"],"@@assign":"optOut"}}}},
+        "Name": "AiGlobalOptOut",
+        "Description": "some description",
+        "PolicyType": "AISERVICES_OPT_OUT_POLICY",
+        "TargetIds": [ "r-abcdef" ]
+    },
+    "awsAccountId": "123456789012",
+    "region": "us-east-1",
+    "logicalResourceIdentifier": "MyResource"
+}

--- a/organizations/policy/__tests__/data-policy/read-success.json
+++ b/organizations/policy/__tests__/data-policy/read-success.json
@@ -1,0 +1,9 @@
+{
+    "clientRequestToken": "4b90a7e4-b790-456b-a937-0cfdfa211dfe",
+    "desiredResourceState": {
+        "ResourceId": "9c9ff813-e56a-4690-a340-56e760897f13"
+    },
+    "awsAccountId": "123456789012",
+    "region": "us-east-1",
+    "logicalResourceIdentifier": "MyResource"
+}

--- a/organizations/policy/__tests__/data-policy/update-success.json
+++ b/organizations/policy/__tests__/data-policy/update-success.json
@@ -1,0 +1,22 @@
+{
+    "clientRequestToken": "4b90a7e4-b790-456b-a937-0cfdfa211dfe",
+    "desiredResourceState": {
+        "ResourceId": "9c9ff813-e56a-4690-a340-56e760897f13",
+        "PolicyDocument": {"services":{"@@operators_allowed_for_child_policies":["@@none"],"default":{"@@operators_allowed_for_child_policies":["@@none"],"opt_out_policy":{"@@operators_allowed_for_child_policies":["@@none"],"@@assign":"optOut"}}}},
+        "Name": "AiGlobalOptOut",
+        "Description": "some other description",
+        "PolicyType": "AISERVICES_OPT_OUT_POLICY",
+        "TargetIds": [ "r-abcdef" ]
+    },
+    "previousResourceState": {
+        "ResourceId": "9c9ff813-e56a-4690-a340-56e760897f13",
+        "PolicyDocument": {"services":{"@@operators_allowed_for_child_policies":["@@none"],"default":{"@@operators_allowed_for_child_policies":["@@none"],"opt_out_policy":{"@@operators_allowed_for_child_policies":["@@none"],"@@assign":"optOut"}}}},
+        "Name": "AiGlobalOptOut",
+        "Description": "some description",
+        "PolicyType": "AISERVICES_OPT_OUT_POLICY",
+        "TargetIds": [ "r-abcdef" ]
+    },
+    "awsAccountId": "123456789012",
+    "region": "us-east-1",
+    "logicalResourceIdentifier": "MyResource"
+}

--- a/organizations/policy/__tests__/handlers-policy.test.ts
+++ b/organizations/policy/__tests__/handlers-policy.test.ts
@@ -1,10 +1,10 @@
 import { Organizations } from 'aws-sdk';
 import { on, AwsServiceMockBuilder } from '@jurijzahn8019/aws-promise-jest-mock';
 import { Action, exceptions, OperationStatus, SessionProxy } from '@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib';
-import createFixture from './data/create-success.json';
-import deleteFixture from './data/delete-success.json';
-import readFixture from './data/read-success.json';
-import updateFixture from './data/update-success.json';
+import createFixture from './data-policy/create-success.json';
+import deleteFixture from './data-policy/delete-success.json';
+import readFixture from './data-policy/read-success.json';
+import updateFixture from './data-policy/update-success.json';
 import { resource } from '../src/handlers';
 
 const IDENTIFIER = '9c9ff813-e56a-4690-a340-56e760897f13';

--- a/organizations/policy/community-organizations-policy.json
+++ b/organizations/policy/community-organizations-policy.json
@@ -12,6 +12,10 @@
             "maxLength": 1000000,
             "pattern": "[\\s\\S]+"
         },
+        "PolicyDocument": {
+            "description": "The policy document to add to the new policy",
+            "type": "object"
+        },
         "Description": {
             "description": "An optional description to assign to the policy.",
             "type": "string",
@@ -57,7 +61,6 @@
     },
     "additionalProperties": false,
     "required": [
-        "Content",
         "Description",
         "Name",
         "PolicyType",

--- a/organizations/policy/docs/README.md
+++ b/organizations/policy/docs/README.md
@@ -13,6 +13,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
     "Type" : "Community::Organizations::Policy",
     "Properties" : {
         "<a href="#content" title="Content">Content</a>" : <i>String</i>,
+        "<a href="#policydocument" title="PolicyDocument">PolicyDocument</a>" : <i>Map</i>,
         "<a href="#description" title="Description">Description</a>" : <i>String</i>,
         "<a href="#name" title="Name">Name</a>" : <i>String</i>,
         "<a href="#policytype" title="PolicyType">PolicyType</a>" : <i>String</i>,
@@ -27,6 +28,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
 Type: Community::Organizations::Policy
 Properties:
     <a href="#content" title="Content">Content</a>: <i>String</i>
+    <a href="#policydocument" title="PolicyDocument">PolicyDocument</a>: <i>Map</i>
     <a href="#description" title="Description">Description</a>: <i>String</i>
     <a href="#name" title="Name">Name</a>: <i>String</i>
     <a href="#policytype" title="PolicyType">PolicyType</a>: <i>String</i>
@@ -40,7 +42,7 @@ Properties:
 
 The policy text content to add to the new policy. The text that you supply must adhere to the rules of the policy type you specify in the Type parameter.
 
-_Required_: Yes
+_Required_: No
 
 _Type_: String
 
@@ -49,6 +51,16 @@ _Minimum_: <code>1</code>
 _Maximum_: <code>1000000</code>
 
 _Pattern_: <code>[\s\S]+</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### PolicyDocument
+
+The policy document to add to the new policy
+
+_Required_: No
+
+_Type_: Map
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/organizations/policy/example-scp.yml
+++ b/organizations/policy/example-scp.yml
@@ -1,0 +1,32 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Example template for a global AI opt-out organizations management policy
+
+Resources:
+  OrganizationPolicy:
+    Type: Community::Organizations::Policy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: DenyLargerThan4XLarge
+            Effect: Deny
+            Action:
+              - "ec2:RunInstances"
+              - "ec2:ModifyInstanceAttribute"
+            Resource: "arn:aws:ec2:*:*:instance/*"
+            Condition:
+              ForAnyValue:StringNotLike:
+                "ec2:InstanceType":
+                  - "*.nano"
+                  - "*.small"
+                  - "*.micro"
+                  - "*.medium"
+                  - "*.large"
+                  - "*.xlarge"
+                  - "*.2xlarge"
+                  - "*.4xlarge"
+      Description: Deny running EC2 instances larger than 4xlarge
+      Name: DenyLargeEC2Instances
+      PolicyType: SERVICE_CONTROL_POLICY
+      TargetIds:
+        - !Ref AWS::AccountId

--- a/organizations/policy/package-lock.json
+++ b/organizations/policy/package-lock.json
@@ -4,6 +4,19 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib/-/cloudformation-cli-typescript-lib-1.0.1.tgz",
+            "integrity": "sha512-degYITXnwEJbkUyWBTRr6dSoly9GKetpvhJ+PB04IX7vKe9+kJcCC0C+fiKSag5e3dLWamf1x6O2jWdgHkRu2Q==",
+            "requires": {
+                "@org-formation/tombok": "^0.0.1",
+                "autobind-decorator": "^2.4.0",
+                "class-transformer": "^0.3.1",
+                "reflect-metadata": "^0.1.13",
+                "string.prototype.replaceall": "^1.0.3",
+                "uuid": "^7.0.2"
+            }
+        },
         "@org-formation/tombok": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/@org-formation/tombok/-/tombok-0.0.1.tgz",
@@ -27,11 +40,10 @@
             "integrity": "sha512-OGYhWUO72V6DafbF8PM8rm3EPbfuyMZcJhtm5/n26IDwO18pohE4eNazLoCGhPiXOCD0gEGmrbU3849QvM8bbw=="
         },
         "aws-resource-providers-common": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/aws-resource-providers-common/-/aws-resource-providers-common-0.3.0.tgz",
-            "integrity": "sha512-6Lt1JWeS13B02Fpe73VLEJNsLU07ZTDlna48kIWLs5u+4zmXHBiVGiGPNM58VeU26AzrYQfDJB/u5fSZHxnikw==",
+            "version": "https://github.com/org-formation/aws-resource-providers/releases/download/common-0.4.0/aws-resource-providers-common-0.4.0.tgz",
+            "integrity": "sha512-N23pLEGSMMVcckiupO0DRBkLuwqhGvbxppz/bdQG4shq6neGh6T8aoO5WkU5bvJvvw6JIDrWw5Bbf5rElOfL8A==",
             "requires": {
-                "cfn-rpdk": "npm:@org-formation/cfn-rpdk@0.x"
+                "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "^1.0.1"
             }
         },
         "aws-sdk": {
@@ -83,19 +95,6 @@
             "requires": {
                 "function-bind": "^1.1.1",
                 "get-intrinsic": "^1.0.0"
-            }
-        },
-        "cfn-rpdk": {
-            "version": "npm:@org-formation/cfn-rpdk@0.5.0",
-            "resolved": "https://registry.npmjs.org/@org-formation/cfn-rpdk/-/cfn-rpdk-0.5.0.tgz",
-            "integrity": "sha512-x/ujnoE19o2+WZl+MLjBQh0VI91tBTtkkQgCkAH7p/HKSXGwgUo+b6idVuY+SDKp2BNPVNRn6+NqBpz/XSxkiQ==",
-            "requires": {
-                "@org-formation/tombok": "^0.0.1",
-                "autobind-decorator": "^2.4.0",
-                "class-transformer": "^0.3.1",
-                "reflect-metadata": "^0.1.13",
-                "string.prototype.replaceall": "^1.0.3",
-                "uuid": "^7.0.2"
             }
         },
         "class-transformer": {

--- a/organizations/policy/package.json
+++ b/organizations/policy/package.json
@@ -1,6 +1,6 @@
 {
     "name": "community-organizations-policy",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "description": "CloudFormation Resource Provider for AWS Organizations Policy",
     "private": true,
     "main": "dist/handlers.js",
@@ -9,7 +9,7 @@
     ],
     "scripts": {
         "build": "npx tsc",
-        "fixrolepath" : "sed 's/Path: \\\"\\/\\\"/Path: \\\"\\/community-types\\/\\\"/g' resource-role.yaml > tmp.txt && mv tmp.txt resource-role.yaml",
+        "fixrolepath": "sed 's/Path: \\\"\\/\\\"/Path: \\\"\\/community-types\\/\\\"/g' resource-role.yaml > tmp.txt && mv tmp.txt resource-role.yaml",
         "prepack": "cfn generate && npm run build && npm run fixrolepath",
         "submit": "npm run prepack && cfn submit -vv --region us-east-1 --set-default",
         "package": "npm run prepack && cfn submit --dry-run -vv && cp ${npm_package_name}.zip ${npm_package_name}-${npm_package_version}.zip",
@@ -34,9 +34,9 @@
         "npm": ">=6.0.0"
     },
     "dependencies": {
-        "aws-resource-providers-common": "^0.3.0",
-        "cfn-rpdk": "npm:@org-formation/cfn-rpdk@^0.5.0",
-        "class-transformer": "^0.3.1",
+        "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "^1.0.1",
+        "aws-resource-providers-common": "https://github.com/org-formation/aws-resource-providers/releases/download/common-0.4.0/aws-resource-providers-common-0.4.0.tgz",
+        "class-transformer": "0.3.1",
         "uuid": "^7.0.3"
     },
     "devDependencies": {

--- a/organizations/policy/resource-role.yaml
+++ b/organizations/policy/resource-role.yaml
@@ -15,7 +15,7 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
-      Path: "/"
+      Path: "/community-types/"
       Policies:
         - PolicyName: ResourceTypePolicy
           PolicyDocument:

--- a/organizations/policy/src/models.ts
+++ b/organizations/policy/src/models.ts
@@ -1,5 +1,5 @@
 // This is a generated file. Modifications will be overwritten.
-import { BaseModel, Dict, integer, Integer, Optional, transformValue } from 'cfn-rpdk';
+import { BaseModel, Dict, integer, Integer, Optional, transformValue } from '@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib';
 import { Exclude, Expose, Type, Transform } from 'class-transformer';
 
 export class ResourceModel extends BaseModel {
@@ -20,6 +20,15 @@ export class ResourceModel extends BaseModel {
         }
     )
     content?: Optional<string>;
+    @Expose({ name: 'PolicyDocument' })
+    @Transform(
+        (value: any, obj: any) =>
+            transformValue(Object, 'policyDocument', value, obj, [Map]),
+        {
+            toClassOnly: true,
+        }
+    )
+    policyDocument?: Optional<Map<string, object>>;
     @Expose({ name: 'Description' })
     @Transform(
         (value: any, obj: any) =>


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/org-formation/aws-resource-providers/issues/78

*Description of changes:*
Added a PolicyDocument attribute to Policy type.
Either Content (string) or PolicyDocument (object) can be used.

