### PR TITLE
Adds Route53 VPC Association Resources

### DIFF
--- a/route53/vpc-association-authorization/.gitignore
+++ b/route53/vpc-association-authorization/.gitignore
@@ -1,0 +1,18 @@
+# Distribution / packaging
+build/
+dist/
+
+# Unit test / coverage reports
+.cache
+.hypothesis/
+.pytest_cache/
+
+# RPDK logs
+rpdk.log*
+
+# Node.js
+node_modules/
+coverage/
+
+# contains credentials
+sam-tests/

--- a/route53/vpc-association-authorization/.npmrc
+++ b/route53/vpc-association-authorization/.npmrc
@@ -1,0 +1,1 @@
+optional = true

--- a/route53/vpc-association-authorization/.rpdk-config
+++ b/route53/vpc-association-authorization/.rpdk-config
@@ -1,0 +1,18 @@
+{
+    "artifact_type": "RESOURCE",
+    "typeName": "Community::Route53::VPCAssociationAuthorization",
+    "language": "typescript",
+    "runtime": "nodejs12.x",
+    "entrypoint": "dist/handlers.entrypoint",
+    "testEntrypoint": "dist/handlers.testEntrypoint",
+    "settings": {
+        "version": false,
+        "subparser_name": null,
+        "verbose": 0,
+        "force": false,
+        "type_name": null,
+        "artifact_type": null,
+        "useDocker": false,
+        "protocolVersion": "2.0.0"
+    }
+}

--- a/route53/vpc-association-authorization/README.md
+++ b/route53/vpc-association-authorization/README.md
@@ -1,0 +1,39 @@
+# Community::Route53::VPCAssociationAuthorization
+
+Congratulations on starting development! Next steps:
+
+1. Write the JSON schema describing your resource, [community-route53-vpcassociationauthorization.json](./community-route53-vpcassociationauthorization.json)
+2. Implement your resource handlers in [handlers.ts](./community-route53-vpcassociationauthorization/handlers.ts)
+
+> Don't modify [models.ts](./community-route53-vpcassociationauthorization/models.ts) by hand, any modifications will be overwritten when the `generate` or `package` commands are run.
+
+Implement CloudFormation resource here. Each function must always return a ProgressEvent.
+
+```typescript
+const progress = ProgressEvent.builder<ProgressEvent<ResourceModel>>()
+
+    // Required
+    // Must be one of OperationStatus.InProgress, OperationStatus.Failed, OperationStatus.Success
+    .status(OperationStatus.InProgress)
+    // Required on SUCCESS (except for LIST where resourceModels is required)
+    // The current resource model after the operation; instance of ResourceModel class
+    .resourceModel(model)
+    .resourceModels(null)
+    // Required on FAILED
+    // Customer-facing message, displayed in e.g. CloudFormation stack events
+    .message('')
+    // Required on FAILED a HandlerErrorCode
+    .errorCode(HandlerErrorCode.InternalFailure)
+    // Optional
+    // Use to store any state between re-invocation via IN_PROGRESS
+    .callbackContext({})
+    // Required on IN_PROGRESS
+    // The number of seconds to delay before re-invocation
+    .callbackDelaySeconds(0)
+
+    .build()
+```
+
+While importing the [@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib](https://github.com/eduardomourar/cloudformation-cli-typescript-plugin) library, failures can be passed back to CloudFormation by either raising an exception from `exceptions`, or setting the ProgressEvent's `status` to `OperationStatus.Failed` and `errorCode` to one of `HandlerErrorCode`. There is a static helper function, `ProgressEvent.failed`, for this common case.
+
+Keep in mind, during runtime all logs will be delivered to CloudWatch if you use the `log()` method from `LoggerProxy` class.

--- a/route53/vpc-association-authorization/__tests__/data/create-success.json
+++ b/route53/vpc-association-authorization/__tests__/data/create-success.json
@@ -1,0 +1,12 @@
+{
+    "clientRequestToken": "4b90a7e4-b790-456b-a937-0cfdfa211dfe",
+    "desiredResourceState": {
+        "HostedZoneId": "Z123456789012345678",
+        "VPC": {
+            "VPCRegion": "us-east-1",
+            "VPCId": "v-12345678901234567"
+        }
+    },
+    "previousResourceState": null,
+    "logicalResourceIdentifier": "MyResource"
+}

--- a/route53/vpc-association-authorization/__tests__/data/delete-success.json
+++ b/route53/vpc-association-authorization/__tests__/data/delete-success.json
@@ -1,0 +1,13 @@
+{
+    "clientRequestToken": "4b90a7e4-b790-456b-a937-0cfdfa211dfe",
+    "desiredResourceState": {
+        "ResourceId": "Z123456789012345678/us-east-1/v-12345678901234567",
+        "HostedZoneId": "Z123456789012345678",
+        "VPC": {
+            "VPCRegion": "us-east-1",
+            "VPCId": "v-12345678901234567"
+        }
+    },
+    "awsAccountId": "123456789012",
+    "logicalResourceIdentifier": "MyResource"
+}

--- a/route53/vpc-association-authorization/__tests__/data/update-success.json
+++ b/route53/vpc-association-authorization/__tests__/data/update-success.json
@@ -1,0 +1,20 @@
+{
+    "clientRequestToken": "4b90a7e4-b790-456b-a937-0cfdfa211dfe",
+    "desiredResourceState": {
+        "HostedZoneId": "Z123456789012345678",
+        "VPC": {
+            "VPCRegion": "us-east-1",
+            "VPCId": "v-12345678901234567"
+        }
+    },
+    "previousResourceState": {
+        "ResourceId": "Z123456789012345678/us-east-1/v-76543210987654321",
+        "HostedZoneId": "Z123456789012345678",
+        "VPC": {
+            "VPCRegion": "us-east-1",
+            "VPCId": "v-76543210987654321"
+        }
+    },
+    "awsAccountId": "123456789012",
+    "logicalResourceIdentifier": "MyResource"
+}

--- a/route53/vpc-association-authorization/__tests__/handlers.test.ts
+++ b/route53/vpc-association-authorization/__tests__/handlers.test.ts
@@ -1,0 +1,87 @@
+import { Route53 } from 'aws-sdk';
+import { on, AwsServiceMockBuilder } from '@jurijzahn8019/aws-promise-jest-mock';
+import { Action, exceptions, OperationStatus, SessionProxy } from '@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib';
+import createFixture from './data/create-success.json';
+import deleteFixture from './data/delete-success.json';
+import updateFixture from './data/update-success.json';
+import { resource } from '../src/handlers';
+
+jest.mock('aws-sdk');
+
+describe('when calling handler', () => {
+    let testEntrypointPayload: any;
+    let spySession: jest.SpyInstance;
+    let spySessionClient: jest.SpyInstance;
+    let route53: AwsServiceMockBuilder<Route53>;
+    let fixtureMap: Map<Action, Record<string, any>>;
+
+    beforeAll(() => {
+        fixtureMap = new Map<Action, Record<string, any>>();
+        fixtureMap.set(Action.Create, createFixture);
+        fixtureMap.set(Action.Update, updateFixture);
+        fixtureMap.set(Action.Delete, deleteFixture);
+    });
+
+    beforeEach(async () => {
+        route53 = on(Route53, { snapshot: false });
+        route53.mock('createVPCAssociationAuthorization').resolve({
+            HostedZoneId: 'Z123456789012345678',
+            VPC: {
+                VPCRegion: 'us-east-1',
+                VPCId: 'v-12345678901234567',
+            },
+        });
+        route53.mock('deleteVPCAssociationAuthorization').resolve({});
+        route53.mock('listVPCAssociationAuthorizations').resolve({
+            VPCs: [
+                {
+                    VPCRegion: 'us-east-1',
+                    VPCId: 'v-12345678901234567',
+                },
+            ],
+        });
+        spySession = jest.spyOn(SessionProxy, 'getSession');
+        spySessionClient = jest.spyOn<any, any>(SessionProxy.prototype, 'client');
+        spySessionClient.mockReturnValue(route53.instance);
+        testEntrypointPayload = {
+            credentials: { accessKeyId: '', secretAccessKey: '', sessionToken: '' },
+            region: 'us-east-1',
+        };
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.restoreAllMocks();
+    });
+
+    test('create operation successful - vpc association', async () => {
+        const request = fixtureMap.get(Action.Create);
+        const progress = await resource.testEntrypoint({ ...testEntrypointPayload, action: Action.Create, request }, null);
+        expect(progress).toMatchObject({ status: OperationStatus.Success, message: '', callbackDelaySeconds: 0 });
+        expect(progress.resourceModel.serialize()).toMatchObject({ ...request.desiredResourceState, ResourceId: 'Z123456789012345678/us-east-1/v-12345678901234567' });
+    });
+
+    test('update operation successful - vpc association', async () => {
+        const request = fixtureMap.get(Action.Update);
+        const progress = await resource.testEntrypoint({ ...testEntrypointPayload, action: Action.Update, request }, null);
+        expect(progress).toMatchObject({ status: OperationStatus.Success, message: '', callbackDelaySeconds: 0 });
+        expect(progress.resourceModel.serialize()).toMatchObject(request.desiredResourceState);
+    });
+
+    test('delete operation successful - vpc association', async () => {
+        const request = fixtureMap.get(Action.Delete);
+        const progress = await resource.testEntrypoint({ ...testEntrypointPayload, action: Action.Delete, request }, null);
+        expect(progress).toMatchObject({ status: OperationStatus.Success, message: '', callbackDelaySeconds: 0 });
+        expect(progress.resourceModel).toBeNull();
+    });
+
+    test('all operations fail without session - vpc association', async () => {
+        expect.assertions(fixtureMap.size);
+        spySession.mockReturnValue(null);
+        for (const [action, request] of fixtureMap) {
+            const progress = await resource.testEntrypoint({ ...testEntrypointPayload, action, request }, null);
+            console.log(JSON.stringify(progress));
+            expect(progress.errorCode).toBe(exceptions.InvalidCredentials.name);
+        }
+    });
+});

--- a/route53/vpc-association-authorization/community-route53-vpcassociationauthorization.json
+++ b/route53/vpc-association-authorization/community-route53-vpcassociationauthorization.json
@@ -1,0 +1,84 @@
+{
+    "typeName": "Community::Route53::VPCAssociationAuthorization",
+    "description": "Creates a VPC Association Authorization.",
+    "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-rpdk.git",
+    "definitions": {
+        "VPC": {
+            "description": "A complex type that contains the VPC ID and region for the VPC that you want to authorize associating with your hosted zone.",
+            "type": "object",
+            "properties": {
+                "VPCRegion": {
+                    "type": "string",
+                    "description": "The region that an Amazon VPC was created in."
+                },
+                "VPCId": {
+                    "type": "string",
+                    "description": "The ID of an Amazon VPC.",
+                    "maxLength": 32
+                }
+            },
+            "required": [
+                "VPCRegion",
+                "VPCId"
+            ],
+            "additionalProperties": false
+        }
+    },
+    "properties": {
+        "ResourceId": {
+            "type": "string",
+            "description": "The ID of this resource."
+        },
+        "HostedZoneId": {
+            "description": "The ID of the private hosted zone that you want to authorize associating a VPC with.",
+            "type": "string"
+        },
+        "VPC": {
+            "$ref": "#/definitions/VPC"
+        }
+    },
+    "additionalProperties": false,
+    "createOnlyProperties": [
+        "/properties/HostedZoneId",
+        "/properties/VPC"
+    ],
+    "replacementStrategy": "create_then_delete",
+    "required": [
+        "HostedZoneId",
+        "VPC"
+    ],
+    "readOnlyProperties": [
+        "/properties/ResourceId"
+    ],
+    "primaryIdentifier": [
+        "/properties/ResourceId"
+    ],
+    "handlers": {
+        "create": {
+            "permissions": [
+                "route53:CreateVPCAssociationAuthorization"
+            ]
+        },
+        "read": {
+            "permissions": [
+                "route53:ListVPCAssociationAuthorizations"
+            ]
+        },
+        "update": {
+            "permissions": [
+                "route53:DeleteVPCAssociationAuthorization",
+                "route53:CreateVPCAssociationAuthorization"
+            ]
+        },
+        "delete": {
+            "permissions": [
+                "route53:DeleteVPCAssociationAuthorization"
+            ]
+        },
+        "list": {
+            "permissions": [
+                "route53:ListVPCAssociationAuthorizations"
+            ]
+        }
+    }
+}

--- a/route53/vpc-association-authorization/docs/README.md
+++ b/route53/vpc-association-authorization/docs/README.md
@@ -1,0 +1,67 @@
+# Community::Route53::VPCAssociationAuthorization
+
+Creates a VPC Association Authorization.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "Type" : "Community::Route53::VPCAssociationAuthorization",
+    "Properties" : {
+        "<a href="#hostedzoneid" title="HostedZoneId">HostedZoneId</a>" : <i>String</i>,
+        "<a href="#vpc" title="VPC">VPC</a>" : <i><a href="vpc.md">VPC</a></i>
+    }
+}
+</pre>
+
+### YAML
+
+<pre>
+Type: Community::Route53::VPCAssociationAuthorization
+Properties:
+    <a href="#hostedzoneid" title="HostedZoneId">HostedZoneId</a>: <i>String</i>
+    <a href="#vpc" title="VPC">VPC</a>: <i><a href="vpc.md">VPC</a></i>
+</pre>
+
+## Properties
+
+#### HostedZoneId
+
+The ID of the private hosted zone that you want to authorize associating a VPC with.
+
+_Required_: Yes
+
+_Type_: String
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### VPC
+
+A complex type that contains the VPC ID and region for the VPC that you want to authorize associating with your hosted zone.
+
+_Required_: Yes
+
+_Type_: <a href="vpc.md">VPC</a>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+## Return Values
+
+### Ref
+
+When you pass the logical ID of this resource to the intrinsic `Ref` function, Ref returns the ResourceId.
+
+### Fn::GetAtt
+
+The `Fn::GetAtt` intrinsic function returns a value for a specified attribute of this type. The following are the available attributes and sample return values.
+
+For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html).
+
+#### ResourceId
+
+The ID of this resource.
+

--- a/route53/vpc-association-authorization/docs/vpc.md
+++ b/route53/vpc-association-authorization/docs/vpc.md
@@ -1,0 +1,48 @@
+# Community::Route53::VPCAssociationAuthorization VPC
+
+A complex type that contains the VPC ID and region for the VPC that you want to authorize associating with your hosted zone.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#vpcregion" title="VPCRegion">VPCRegion</a>" : <i>String</i>,
+    "<a href="#vpcid" title="VPCId">VPCId</a>" : <i>String</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#vpcregion" title="VPCRegion">VPCRegion</a>: <i>String</i>
+<a href="#vpcid" title="VPCId">VPCId</a>: <i>String</i>
+</pre>
+
+## Properties
+
+#### VPCRegion
+
+The region that an Amazon VPC was created in.
+
+_Required_: Yes
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### VPCId
+
+The ID of an Amazon VPC.
+
+_Required_: Yes
+
+_Type_: String
+
+_Maximum_: <code>32</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/route53/vpc-association-authorization/package-lock.json
+++ b/route53/vpc-association-authorization/package-lock.json
@@ -1,0 +1,969 @@
+{
+    "name": "community-route53-vpcassociationauthorization",
+    "version": "0.1.0",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "community-route53-vpcassociationauthorization",
+            "version": "0.1.0",
+            "dependencies": {
+                "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "^1.0.1",
+                "aws-resource-providers-common": "https://github.com/org-formation/aws-resource-providers/releases/download/common-0.4.0/aws-resource-providers-common-0.4.0.tgz",
+                "class-transformer": "0.3.1"
+            },
+            "devDependencies": {
+                "@types/node": "^12.0.0",
+                "typescript": "^4.1.2"
+            },
+            "optionalDependencies": {
+                "aws-sdk": "^2.656.0"
+            }
+        },
+        "node_modules/@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib/-/cloudformation-cli-typescript-lib-1.0.1.tgz",
+            "integrity": "sha512-degYITXnwEJbkUyWBTRr6dSoly9GKetpvhJ+PB04IX7vKe9+kJcCC0C+fiKSag5e3dLWamf1x6O2jWdgHkRu2Q==",
+            "dependencies": {
+                "@org-formation/tombok": "^0.0.1",
+                "autobind-decorator": "^2.4.0",
+                "class-transformer": "^0.3.1",
+                "reflect-metadata": "^0.1.13",
+                "string.prototype.replaceall": "^1.0.3",
+                "uuid": "^7.0.2"
+            },
+            "engines": {
+                "node": ">=12.0.0",
+                "npm": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "aws-sdk": "^2.712.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-sdk": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@org-formation/tombok": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@org-formation/tombok/-/tombok-0.0.1.tgz",
+            "integrity": "sha512-6F0zitevY+H3VT3MVsAo4JFlDl5kfqnhGLUwXNc652/HYEBzMru5iLkTIF6+cp/lgvTWxQJQJzH4yoYja2f9Pg==",
+            "engines": {
+                "node": ">=10.0.0",
+                "npm": ">=5.6.0"
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "12.20.14",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.14.tgz",
+            "integrity": "sha512-iFJOS5Q470FF+r4Ol2pSley7/wCNVqf+jgjhtxLLaJcDs+To2iCxlXIkJXrGLD9w9G/oJ9ibySu7z92DCwr7Pg==",
+            "dev": true
+        },
+        "node_modules/autobind-decorator": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/autobind-decorator/-/autobind-decorator-2.4.0.tgz",
+            "integrity": "sha512-OGYhWUO72V6DafbF8PM8rm3EPbfuyMZcJhtm5/n26IDwO18pohE4eNazLoCGhPiXOCD0gEGmrbU3849QvM8bbw==",
+            "engines": {
+                "node": ">=8.10",
+                "npm": ">=6.4.1"
+            }
+        },
+        "node_modules/aws-resource-providers-common": {
+            "version": "0.4.0",
+            "resolved": "https://github.com/org-formation/aws-resource-providers/releases/download/common-0.4.0/aws-resource-providers-common-0.4.0.tgz",
+            "integrity": "sha512-N23pLEGSMMVcckiupO0DRBkLuwqhGvbxppz/bdQG4shq6neGh6T8aoO5WkU5bvJvvw6JIDrWw5Bbf5rElOfL8A==",
+            "license": "MIT",
+            "dependencies": {
+                "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "^1.0.1"
+            },
+            "peerDependencies": {
+                "aws-sdk": "^2.656.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-sdk": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/aws-sdk": {
+            "version": "2.920.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.920.0.tgz",
+            "integrity": "sha512-tbMZ/Y2rRo6R6TTBODJXTiil+MXaoT6Qzotws3yvI1IWGpYxKo7N/3L06XB8ul8tCG0TigxIOY70SMICM70Ppg==",
+            "hasInstallScript": true,
+            "optional": true,
+            "dependencies": {
+                "buffer": "4.9.2",
+                "events": "1.1.1",
+                "ieee754": "1.1.13",
+                "jmespath": "0.15.0",
+                "querystring": "0.2.0",
+                "sax": "1.2.1",
+                "url": "0.10.3",
+                "uuid": "3.3.2",
+                "xml2js": "0.4.19"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/aws-sdk/node_modules/uuid": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+            "optional": true,
+            "bin": {
+                "uuid": "bin/uuid"
+            }
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "optional": true
+        },
+        "node_modules/buffer": {
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+            "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+            "optional": true,
+            "dependencies": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
+            }
+        },
+        "node_modules/call-bind": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "dependencies": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/class-transformer": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.3.1.tgz",
+            "integrity": "sha512-cKFwohpJbuMovS8xVLmn8N2AUbAuc8pVo4zEfsUVo8qgECOogns1WVk/FkOZoxhOPTyTYFckuoH+13FO+MQ8GA=="
+        },
+        "node_modules/define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dependencies": {
+                "object-keys": "^1.0.12"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-abstract": {
+            "version": "1.18.3",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+            "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.2",
+                "is-callable": "^1.2.3",
+                "is-negative-zero": "^2.0.1",
+                "is-regex": "^1.1.3",
+                "is-string": "^1.0.6",
+                "object-inspect": "^1.10.3",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.2",
+                "string.prototype.trimend": "^1.0.4",
+                "string.prototype.trimstart": "^1.0.4",
+                "unbox-primitive": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/es-to-primitive": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "dependencies": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/events": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+            "optional": true,
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+            "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+            "dependencies": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dependencies": {
+                "function-bind": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/has-bigints": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+            "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+            "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/ieee754": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+            "optional": true
+        },
+        "node_modules/is-bigint": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+            "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-boolean-object": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+            "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
+            "dependencies": {
+                "call-bind": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-callable": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+            "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-date-object": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+            "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-negative-zero": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+            "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-number-object": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+            "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-regex": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+            "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-symbols": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-string": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+            "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-symbol": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+            "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+            "dependencies": {
+                "has-symbols": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "optional": true
+        },
+        "node_modules/jmespath": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+            "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+            "optional": true,
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
+        "node_modules/object-inspect": {
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+            "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/object.assign": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+            "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+            "dependencies": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3",
+                "has-symbols": "^1.0.1",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/punycode": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+            "optional": true
+        },
+        "node_modules/querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "optional": true,
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/reflect-metadata": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+            "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+        },
+        "node_modules/sax": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+            "optional": true
+        },
+        "node_modules/string.prototype.replaceall": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/string.prototype.replaceall/-/string.prototype.replaceall-1.0.5.tgz",
+            "integrity": "sha512-YUjdWElI9pgKo7mrPOMKHFZxcAa0v1uqoJkMHtlJW63rMkPLkQH71ao2XNkKY2ksHKHC8ZUFwNjN9Vry+QyCvg==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.18.0-next.2",
+                "get-intrinsic": "^1.1.1",
+                "has-symbols": "^1.0.1",
+                "is-regex": "^1.1.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/string.prototype.trimend": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+            "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/string.prototype.trimstart": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+            "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+            "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/unbox-primitive": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+            "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+            "dependencies": {
+                "function-bind": "^1.1.1",
+                "has-bigints": "^1.0.1",
+                "has-symbols": "^1.0.2",
+                "which-boxed-primitive": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/url": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+            "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+            "optional": true,
+            "dependencies": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            }
+        },
+        "node_modules/uuid": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+            "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/which-boxed-primitive": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+            "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+            "dependencies": {
+                "is-bigint": "^1.0.1",
+                "is-boolean-object": "^1.1.0",
+                "is-number-object": "^1.0.4",
+                "is-string": "^1.0.5",
+                "is-symbol": "^1.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/xml2js": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "optional": true,
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
+            }
+        },
+        "node_modules/xmlbuilder": {
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+            "optional": true,
+            "engines": {
+                "node": ">=4.0"
+            }
+        }
+    },
+    "dependencies": {
+        "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib/-/cloudformation-cli-typescript-lib-1.0.1.tgz",
+            "integrity": "sha512-degYITXnwEJbkUyWBTRr6dSoly9GKetpvhJ+PB04IX7vKe9+kJcCC0C+fiKSag5e3dLWamf1x6O2jWdgHkRu2Q==",
+            "requires": {
+                "@org-formation/tombok": "^0.0.1",
+                "autobind-decorator": "^2.4.0",
+                "class-transformer": "^0.3.1",
+                "reflect-metadata": "^0.1.13",
+                "string.prototype.replaceall": "^1.0.3",
+                "uuid": "^7.0.2"
+            }
+        },
+        "@org-formation/tombok": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@org-formation/tombok/-/tombok-0.0.1.tgz",
+            "integrity": "sha512-6F0zitevY+H3VT3MVsAo4JFlDl5kfqnhGLUwXNc652/HYEBzMru5iLkTIF6+cp/lgvTWxQJQJzH4yoYja2f9Pg=="
+        },
+        "@types/node": {
+            "version": "12.20.14",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.14.tgz",
+            "integrity": "sha512-iFJOS5Q470FF+r4Ol2pSley7/wCNVqf+jgjhtxLLaJcDs+To2iCxlXIkJXrGLD9w9G/oJ9ibySu7z92DCwr7Pg==",
+            "dev": true
+        },
+        "autobind-decorator": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/autobind-decorator/-/autobind-decorator-2.4.0.tgz",
+            "integrity": "sha512-OGYhWUO72V6DafbF8PM8rm3EPbfuyMZcJhtm5/n26IDwO18pohE4eNazLoCGhPiXOCD0gEGmrbU3849QvM8bbw=="
+        },
+        "aws-resource-providers-common": {
+            "version": "https://github.com/org-formation/aws-resource-providers/releases/download/common-0.4.0/aws-resource-providers-common-0.4.0.tgz",
+            "integrity": "sha512-N23pLEGSMMVcckiupO0DRBkLuwqhGvbxppz/bdQG4shq6neGh6T8aoO5WkU5bvJvvw6JIDrWw5Bbf5rElOfL8A==",
+            "requires": {
+                "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "^1.0.1"
+            }
+        },
+        "aws-sdk": {
+            "version": "2.920.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.920.0.tgz",
+            "integrity": "sha512-tbMZ/Y2rRo6R6TTBODJXTiil+MXaoT6Qzotws3yvI1IWGpYxKo7N/3L06XB8ul8tCG0TigxIOY70SMICM70Ppg==",
+            "optional": true,
+            "requires": {
+                "buffer": "4.9.2",
+                "events": "1.1.1",
+                "ieee754": "1.1.13",
+                "jmespath": "0.15.0",
+                "querystring": "0.2.0",
+                "sax": "1.2.1",
+                "url": "0.10.3",
+                "uuid": "3.3.2",
+                "xml2js": "0.4.19"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "3.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+                    "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+                    "optional": true
+                }
+            }
+        },
+        "base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "optional": true
+        },
+        "buffer": {
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+            "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+            "optional": true,
+            "requires": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
+            }
+        },
+        "call-bind": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+            }
+        },
+        "class-transformer": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.3.1.tgz",
+            "integrity": "sha512-cKFwohpJbuMovS8xVLmn8N2AUbAuc8pVo4zEfsUVo8qgECOogns1WVk/FkOZoxhOPTyTYFckuoH+13FO+MQ8GA=="
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "requires": {
+                "object-keys": "^1.0.12"
+            }
+        },
+        "es-abstract": {
+            "version": "1.18.3",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+            "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.2",
+                "is-callable": "^1.2.3",
+                "is-negative-zero": "^2.0.1",
+                "is-regex": "^1.1.3",
+                "is-string": "^1.0.6",
+                "object-inspect": "^1.10.3",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.2",
+                "string.prototype.trimend": "^1.0.4",
+                "string.prototype.trimstart": "^1.0.4",
+                "unbox-primitive": "^1.0.1"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
+        "events": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+            "optional": true
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+        },
+        "get-intrinsic": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+            "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1"
+            }
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
+        "has-bigints": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+            "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+        },
+        "has-symbols": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+            "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+        },
+        "ieee754": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+            "optional": true
+        },
+        "is-bigint": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+            "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA=="
+        },
+        "is-boolean-object": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+            "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
+            "requires": {
+                "call-bind": "^1.0.2"
+            }
+        },
+        "is-callable": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+            "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
+        },
+        "is-date-object": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+            "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A=="
+        },
+        "is-negative-zero": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+            "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+        },
+        "is-number-object": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+            "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw=="
+        },
+        "is-regex": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+            "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-symbols": "^1.0.2"
+            }
+        },
+        "is-string": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+            "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w=="
+        },
+        "is-symbol": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+            "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+            "requires": {
+                "has-symbols": "^1.0.2"
+            }
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "optional": true
+        },
+        "jmespath": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+            "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+            "optional": true
+        },
+        "object-inspect": {
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+            "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        },
+        "object.assign": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+            "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+            "requires": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3",
+                "has-symbols": "^1.0.1",
+                "object-keys": "^1.1.1"
+            }
+        },
+        "punycode": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+            "optional": true
+        },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "optional": true
+        },
+        "reflect-metadata": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+            "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+        },
+        "sax": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+            "optional": true
+        },
+        "string.prototype.replaceall": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/string.prototype.replaceall/-/string.prototype.replaceall-1.0.5.tgz",
+            "integrity": "sha512-YUjdWElI9pgKo7mrPOMKHFZxcAa0v1uqoJkMHtlJW63rMkPLkQH71ao2XNkKY2ksHKHC8ZUFwNjN9Vry+QyCvg==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.18.0-next.2",
+                "get-intrinsic": "^1.1.1",
+                "has-symbols": "^1.0.1",
+                "is-regex": "^1.1.2"
+            }
+        },
+        "string.prototype.trimend": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+            "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            }
+        },
+        "string.prototype.trimstart": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+            "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            }
+        },
+        "typescript": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+            "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+            "dev": true
+        },
+        "unbox-primitive": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+            "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has-bigints": "^1.0.1",
+                "has-symbols": "^1.0.2",
+                "which-boxed-primitive": "^1.0.2"
+            }
+        },
+        "url": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+            "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+            "optional": true,
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            }
+        },
+        "uuid": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+            "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+        },
+        "which-boxed-primitive": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+            "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+            "requires": {
+                "is-bigint": "^1.0.1",
+                "is-boolean-object": "^1.1.0",
+                "is-number-object": "^1.0.4",
+                "is-string": "^1.0.5",
+                "is-symbol": "^1.0.3"
+            }
+        },
+        "xml2js": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "optional": true,
+            "requires": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
+            }
+        },
+        "xmlbuilder": {
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+            "optional": true
+        }
+    }
+}

--- a/route53/vpc-association-authorization/package.json
+++ b/route53/vpc-association-authorization/package.json
@@ -1,0 +1,35 @@
+{
+    "name": "community-route53-vpcassociationauthorization",
+    "version": "0.1.0",
+    "description": "AWS custom resource provider named Community::Route53::VPCAssociationAuthorization.",
+    "private": true,
+    "main": "dist/handlers.js",
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "npx tsc",
+        "fixrolepath": "sed 's/Path: \\\"\\/\\\"/Path: \\\"\\/community-types\\/\\\"/g' resource-role.yaml > tmp.txt && mv tmp.txt resource-role.yaml",
+        "prepack": "cfn generate && npm run build && npm run fixrolepath",
+        "submit": "npm run prepack && cfn submit -vv --region us-east-1 --set-default",
+        "package": "npm run prepack && cfn submit --dry-run -vv && cp ${npm_package_name}.zip ${npm_package_name}-${npm_package_version}.zip",
+        "version": "npm run package && aws s3 cp ${npm_package_name}-${npm_package_version}.zip s3://community-resource-provider-catalog/${npm_package_name}-${npm_package_version}.zip && aws s3 cp resource-role.yaml s3://community-resource-provider-catalog/${npm_package_name}-resource-role-${npm_package_version}.yml",
+        "test": "npx jest",
+        "test:integration": "npx npm-run-all -p -r samstart cfntest",
+        "cfntest": "cfn test -vv >> cfn.log",
+        "samstart": "sam local start-lambda -l sam.log",
+        "validate": "cfn validate"
+    },
+    "dependencies": {
+        "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "^1.0.1",
+        "aws-resource-providers-common": "https://github.com/org-formation/aws-resource-providers/releases/download/common-0.4.0/aws-resource-providers-common-0.4.0.tgz",
+        "class-transformer": "0.3.1"
+    },
+    "devDependencies": {
+        "@types/node": "^12.0.0",
+        "typescript": "^4.1.2"
+    },
+    "optionalDependencies": {
+        "aws-sdk": "^2.656.0"
+    }
+}

--- a/route53/vpc-association-authorization/resource-role.yaml
+++ b/route53/vpc-association-authorization/resource-role.yaml
@@ -1,0 +1,33 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  This CloudFormation template creates a role assumed by CloudFormation
+  during CRUDL operations to mutate resources on behalf of the customer.
+
+Resources:
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      MaxSessionDuration: 8400
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: resources.cloudformation.amazonaws.com
+            Action: sts:AssumeRole
+      Path: "/community-types/"
+      Policies:
+        - PolicyName: ResourceTypePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                - "route53:CreateVPCAssociationAuthorization"
+                - "route53:DeleteVPCAssociationAuthorization"
+                - "route53:ListVPCAssociationAuthorizations"
+                Resource: "*"
+Outputs:
+  ExecutionRoleArn:
+    Value:
+      Fn::GetAtt: ExecutionRole.Arn

--- a/route53/vpc-association-authorization/src/handlers.ts
+++ b/route53/vpc-association-authorization/src/handlers.ts
@@ -1,0 +1,99 @@
+import { Route53 } from 'aws-sdk';
+import { commonAws, HandlerArgs } from 'aws-resource-providers-common';
+import { Action, BaseResource, exceptions, handlerEvent, Logger } from '@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib';
+
+import { ResourceModel, VPC } from './models';
+
+class Resource extends BaseResource<ResourceModel> {
+    private async createVpcAssociationAuthorization(action: Action, service: Route53, logger: Logger, model: ResourceModel): Promise<ResourceModel> {
+        const request: Route53.CreateVPCAssociationAuthorizationRequest = {
+            HostedZoneId: model.hostedZoneId,
+            VPC: {
+                VPCId: model.vPC.vPCId,
+                VPCRegion: model.vPC.vPCRegion,
+            },
+        };
+        logger.log({ action, message: 'before invoke createVPCAssociationAuthorization', request });
+        const response = await service.createVPCAssociationAuthorization(request).promise();
+        logger.log({ action, message: 'after invoke createVPCAssociationAuthorization', response });
+        logger.log({ action, message: 'done', model });
+        model.resourceId = `${model.hostedZoneId}/${model.vPC.vPCRegion}/${model.vPC.vPCId}`;
+        return model;
+    }
+
+    private async deleteVpcAssociationAuthorization(action: Action, service: Route53, logger: Logger, model: ResourceModel): Promise<null> {
+        const request: Route53.DeleteVPCAssociationAuthorizationRequest = {
+            HostedZoneId: model.hostedZoneId,
+            VPC: {
+                VPCId: model.vPC.vPCId,
+                VPCRegion: model.vPC.vPCRegion,
+            },
+        };
+        logger.log({ action, message: 'before invoke deleteVPCAssociationAuthorization', request });
+        const response = await service.deleteVPCAssociationAuthorization(request).promise();
+        logger.log({ action, message: 'after invoke deleteVPCAssociationAuthorization', response });
+        logger.log({ action, message: 'done', model });
+        return null;
+    }
+
+    private async listVPCAssociationAuthorizations(action: Action, service: Route53, logger: Logger, model: ResourceModel): Promise<Route53.VPC[]> {
+        const request: Route53.ListVPCAssociationAuthorizationsRequest = { HostedZoneId: model.hostedZoneId };
+        logger.log({ action, message: 'before invoke createVPCAssociationAuthorization', request });
+        let vpcs: Array<Route53.VPC> = [];
+        let response = await service.listVPCAssociationAuthorizations(request).promise();
+        vpcs = vpcs.concat(response.VPCs);
+        logger.log({ action, message: 'after invoke createVPCAssociationAuthorization', response });
+        logger.log({ action, message: 'done', model });
+        while (response.NextToken) {
+            logger.log({ action, message: 'before invoke createVPCAssociationAuthorization', request });
+            response = await service.listVPCAssociationAuthorizations(request).promise();
+            vpcs = vpcs.concat(response.VPCs);
+            logger.log({ action, message: 'after invoke createVPCAssociationAuthorization', response });
+            logger.log({ action, message: 'done', model });
+        }
+        return vpcs;
+    }
+
+    @handlerEvent(Action.Create)
+    @commonAws({ serviceName: 'Route53', debug: true })
+    public async create(action: Action, args: HandlerArgs<ResourceModel>, service: Route53, model: ResourceModel): Promise<ResourceModel> {
+        if (model.resourceId) throw new exceptions.InvalidRequest('Read only property [ResourceId] cannot be provided by the user.');
+        return this.createVpcAssociationAuthorization(action, service, args.logger, model);
+    }
+
+    @handlerEvent(Action.Update)
+    @commonAws({ serviceName: 'Route53', debug: true })
+    public async update(action: Action, args: HandlerArgs<ResourceModel>, service: Route53, model: ResourceModel): Promise<ResourceModel> {
+        if (model.resourceId) throw new exceptions.InvalidRequest('Read only property [ResourceId] cannot be provided by the user.');
+        return this.createVpcAssociationAuthorization(action, service, args.logger, model);
+    }
+
+    @handlerEvent(Action.Delete)
+    @commonAws({ serviceName: 'Route53', debug: true })
+    public async delete(action: Action, args: HandlerArgs<ResourceModel>, service: Route53, model: ResourceModel): Promise<null> {
+        return this.deleteVpcAssociationAuthorization(action, service, args.logger, model);
+    }
+
+    @handlerEvent(Action.Read)
+    @commonAws({ serviceName: 'Route53', debug: true })
+    public async read(action: Action, args: HandlerArgs<ResourceModel>, service: Route53, model: ResourceModel): Promise<ResourceModel> {
+        const [hostedZoneId, vpcRegion, vpcId] = model.resourceId.split('/');
+        const vpcs = await this.listVPCAssociationAuthorizations(action, service, args.logger, model);
+        const targetVpc = vpcs.find((vpc) => vpc.VPCId === vpcId && vpc.VPCRegion === vpcRegion);
+        if (!targetVpc) throw new exceptions.NotFound(this.typeName, model.resourceId);
+        model.hostedZoneId = hostedZoneId;
+        model.vPC = VPC.deserialize({
+            vPCRegion: vpcRegion,
+            vPCId: vpcId,
+        });
+        return model;
+    }
+}
+
+export const resource = new Resource(ResourceModel.TYPE_NAME, ResourceModel);
+
+// Entrypoint for production usage after registered in CloudFormation
+export const entrypoint = resource.entrypoint;
+
+// Entrypoint used for local testing
+export const testEntrypoint = resource.testEntrypoint;

--- a/route53/vpc-association-authorization/src/models.ts
+++ b/route53/vpc-association-authorization/src/models.ts
@@ -1,0 +1,79 @@
+// This is a generated file. Modifications will be overwritten.
+import { BaseModel, Dict, integer, Integer, Optional, transformValue } from '@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib';
+import { Exclude, Expose, Type, Transform } from 'class-transformer';
+
+export class ResourceModel extends BaseModel {
+    ['constructor']: typeof ResourceModel;
+
+    @Exclude()
+    public static readonly TYPE_NAME: string = 'Community::Route53::VPCAssociationAuthorization';
+
+    @Exclude()
+    protected readonly IDENTIFIER_KEY_RESOURCEID: string = '/properties/ResourceId';
+
+    @Expose({ name: 'ResourceId' })
+    @Transform(
+        (value: any, obj: any) =>
+            transformValue(String, 'resourceId', value, obj, []),
+        {
+            toClassOnly: true,
+        }
+    )
+    resourceId?: Optional<string>;
+    @Expose({ name: 'HostedZoneId' })
+    @Transform(
+        (value: any, obj: any) =>
+            transformValue(String, 'hostedZoneId', value, obj, []),
+        {
+            toClassOnly: true,
+        }
+    )
+    hostedZoneId?: Optional<string>;
+    @Expose({ name: 'VPC' })
+    @Type(() => VPC)
+    vPC?: Optional<VPC>;
+
+    @Exclude()
+    public getPrimaryIdentifier(): Dict {
+        const identifier: Dict = {};
+        if (this.resourceId != null) {
+            identifier[this.IDENTIFIER_KEY_RESOURCEID] = this.resourceId;
+        }
+
+        // only return the identifier if it can be used, i.e. if all components are present
+        return Object.keys(identifier).length === 1 ? identifier : null;
+    }
+
+    @Exclude()
+    public getAdditionalIdentifiers(): Array<Dict> {
+        const identifiers: Array<Dict> = new Array<Dict>();
+        // only return the identifiers if any can be used
+        return identifiers.length === 0 ? null : identifiers;
+    }
+}
+
+export class VPC extends BaseModel {
+    ['constructor']: typeof VPC;
+
+
+    @Expose({ name: 'VPCRegion' })
+    @Transform(
+        (value: any, obj: any) =>
+            transformValue(String, 'vPCRegion', value, obj, []),
+        {
+            toClassOnly: true,
+        }
+    )
+    vPCRegion?: Optional<string>;
+    @Expose({ name: 'VPCId' })
+    @Transform(
+        (value: any, obj: any) =>
+            transformValue(String, 'vPCId', value, obj, []),
+        {
+            toClassOnly: true,
+        }
+    )
+    vPCId?: Optional<string>;
+
+}
+

--- a/route53/vpc-association-authorization/template.yml
+++ b/route53/vpc-association-authorization/template.yml
@@ -1,0 +1,24 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: AWS SAM template for the Community::Route53::VPCAssociationAuthorization resource type
+
+Globals:
+  Function:
+    Timeout: 180  # docker start-up times can be long for SAM CLI
+    MemorySize: 256
+
+Resources:
+  TestEntrypoint:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: dist/handlers.testEntrypoint
+      Runtime: nodejs12.x
+      CodeUri: ./
+
+  TypeFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: dist/handlers.entrypoint
+      Runtime: nodejs12.x
+      CodeUri: ./
+

--- a/route53/vpc-association-authorization/tsconfig.json
+++ b/route53/vpc-association-authorization/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+        "target": "ES2017",
+        "module": "commonjs",
+        "noImplicitAny": true,
+        "alwaysStrict": true,
+        "esModuleInterop": true,
+        "moduleResolution": "node",
+        "allowJs": true,
+        "experimentalDecorators": true,
+        "outDir": "dist"
+    },
+    "include": [
+        "src/**/*.ts"
+    ],
+    "exclude": [
+        "node_modules"
+    ]
+}

--- a/route53/vpc-association/.gitignore
+++ b/route53/vpc-association/.gitignore
@@ -1,0 +1,18 @@
+# Distribution / packaging
+build/
+dist/
+
+# Unit test / coverage reports
+.cache
+.hypothesis/
+.pytest_cache/
+
+# RPDK logs
+rpdk.log*
+
+# Node.js
+node_modules/
+coverage/
+
+# contains credentials
+sam-tests/

--- a/route53/vpc-association/.npmrc
+++ b/route53/vpc-association/.npmrc
@@ -1,0 +1,1 @@
+optional = true

--- a/route53/vpc-association/.rpdk-config
+++ b/route53/vpc-association/.rpdk-config
@@ -1,0 +1,18 @@
+{
+    "artifact_type": "RESOURCE",
+    "typeName": "Community::Route53::VPCAssociation",
+    "language": "typescript",
+    "runtime": "nodejs12.x",
+    "entrypoint": "dist/handlers.entrypoint",
+    "testEntrypoint": "dist/handlers.testEntrypoint",
+    "settings": {
+        "version": false,
+        "subparser_name": null,
+        "verbose": 0,
+        "force": false,
+        "type_name": null,
+        "artifact_type": null,
+        "useDocker": false,
+        "protocolVersion": "2.0.0"
+    }
+}

--- a/route53/vpc-association/README.md
+++ b/route53/vpc-association/README.md
@@ -1,0 +1,39 @@
+# Community::Route53::VPCAssociation
+
+Congratulations on starting development! Next steps:
+
+1. Write the JSON schema describing your resource, [community-route53-vpcassociation.json](./community-route53-vpcassociation.json)
+2. Implement your resource handlers in [handlers.ts](./community-route53-vpcassociation/handlers.ts)
+
+> Don't modify [models.ts](./community-route53-vpcassociation/models.ts) by hand, any modifications will be overwritten when the `generate` or `package` commands are run.
+
+Implement CloudFormation resource here. Each function must always return a ProgressEvent.
+
+```typescript
+const progress = ProgressEvent.builder<ProgressEvent<ResourceModel>>()
+
+    // Required
+    // Must be one of OperationStatus.InProgress, OperationStatus.Failed, OperationStatus.Success
+    .status(OperationStatus.InProgress)
+    // Required on SUCCESS (except for LIST where resourceModels is required)
+    // The current resource model after the operation; instance of ResourceModel class
+    .resourceModel(model)
+    .resourceModels(null)
+    // Required on FAILED
+    // Customer-facing message, displayed in e.g. CloudFormation stack events
+    .message('')
+    // Required on FAILED a HandlerErrorCode
+    .errorCode(HandlerErrorCode.InternalFailure)
+    // Optional
+    // Use to store any state between re-invocation via IN_PROGRESS
+    .callbackContext({})
+    // Required on IN_PROGRESS
+    // The number of seconds to delay before re-invocation
+    .callbackDelaySeconds(0)
+
+    .build()
+```
+
+While importing the [@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib](https://github.com/eduardomourar/cloudformation-cli-typescript-plugin) library, failures can be passed back to CloudFormation by either raising an exception from `exceptions`, or setting the ProgressEvent's `status` to `OperationStatus.Failed` and `errorCode` to one of `HandlerErrorCode`. There is a static helper function, `ProgressEvent.failed`, for this common case.
+
+Keep in mind, during runtime all logs will be delivered to CloudWatch if you use the `log()` method from `LoggerProxy` class.

--- a/route53/vpc-association/__tests__/data/create-success.json
+++ b/route53/vpc-association/__tests__/data/create-success.json
@@ -1,0 +1,12 @@
+{
+    "clientRequestToken": "4b90a7e4-b790-456b-a937-0cfdfa211dfe",
+    "desiredResourceState": {
+        "HostedZoneId": "Z123456789012345678",
+        "VPC": {
+            "VPCRegion": "us-east-1",
+            "VPCId": "v-12345678901234567"
+        }
+    },
+    "previousResourceState": null,
+    "logicalResourceIdentifier": "MyResource"
+}

--- a/route53/vpc-association/__tests__/data/delete-success.json
+++ b/route53/vpc-association/__tests__/data/delete-success.json
@@ -1,0 +1,13 @@
+{
+    "clientRequestToken": "4b90a7e4-b790-456b-a937-0cfdfa211dfe",
+    "desiredResourceState": {
+        "ResourceId": "Z123456789012345678/us-east-1/v-12345678901234567",
+        "HostedZoneId": "Z123456789012345678",
+        "VPC": {
+            "VPCRegion": "us-east-1",
+            "VPCId": "v-12345678901234567"
+        }
+    },
+    "awsAccountId": "123456789012",
+    "logicalResourceIdentifier": "MyResource"
+}

--- a/route53/vpc-association/__tests__/data/update-success.json
+++ b/route53/vpc-association/__tests__/data/update-success.json
@@ -1,0 +1,20 @@
+{
+    "clientRequestToken": "4b90a7e4-b790-456b-a937-0cfdfa211dfe",
+    "desiredResourceState": {
+        "HostedZoneId": "Z123456789012345678",
+        "VPC": {
+            "VPCRegion": "us-east-1",
+            "VPCId": "v-12345678901234567"
+        }
+    },
+    "previousResourceState": {
+        "ResourceId": "Z123456789012345678/us-east-1/v-76543210987654321",
+        "HostedZoneId": "Z123456789012345678",
+        "VPC": {
+            "VPCRegion": "us-east-1",
+            "VPCId": "v-76543210987654321"
+        }
+    },
+    "awsAccountId": "123456789012",
+    "logicalResourceIdentifier": "MyResource"
+}

--- a/route53/vpc-association/__tests__/handlers.test.ts
+++ b/route53/vpc-association/__tests__/handlers.test.ts
@@ -1,0 +1,87 @@
+import { Route53 } from 'aws-sdk';
+import { on, AwsServiceMockBuilder } from '@jurijzahn8019/aws-promise-jest-mock';
+import { Action, exceptions, OperationStatus, SessionProxy } from '@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib';
+import createFixture from './data/create-success.json';
+import deleteFixture from './data/delete-success.json';
+import updateFixture from './data/update-success.json';
+import { resource } from '../src/handlers';
+
+jest.mock('aws-sdk');
+
+describe('when calling handler', () => {
+    let testEntrypointPayload: any;
+    let spySession: jest.SpyInstance;
+    let spySessionClient: jest.SpyInstance;
+    let route53: AwsServiceMockBuilder<Route53>;
+    let fixtureMap: Map<Action, Record<string, any>>;
+
+    beforeAll(() => {
+        fixtureMap = new Map<Action, Record<string, any>>();
+        fixtureMap.set(Action.Create, createFixture);
+        fixtureMap.set(Action.Update, updateFixture);
+        fixtureMap.set(Action.Delete, deleteFixture);
+    });
+
+    beforeEach(async () => {
+        route53 = on(Route53, { snapshot: false });
+        route53.mock('associateVPCWithHostedZone').resolve({
+            ChangeInfo: {
+                Id: 'someId',
+                Status: 'PENDING',
+                SubmittedAt: new Date(),
+                Comment: '',
+            },
+        });
+        route53.mock('disassociateVPCFromHostedZone').resolve({
+            ChangeInfo: {
+                Id: 'someId',
+                Status: 'PENDING',
+                SubmittedAt: new Date(),
+                Comment: '',
+            },
+        });
+        spySession = jest.spyOn(SessionProxy, 'getSession');
+        spySessionClient = jest.spyOn<any, any>(SessionProxy.prototype, 'client');
+        spySessionClient.mockReturnValue(route53.instance);
+        testEntrypointPayload = {
+            credentials: { accessKeyId: '', secretAccessKey: '', sessionToken: '' },
+            region: 'us-east-1',
+        };
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+        jest.restoreAllMocks();
+    });
+
+    test('create operation successful - vpc association', async () => {
+        const request = fixtureMap.get(Action.Create);
+        const progress = await resource.testEntrypoint({ ...testEntrypointPayload, action: Action.Create, request }, null);
+        expect(progress).toMatchObject({ status: OperationStatus.Success, message: '', callbackDelaySeconds: 0 });
+        expect(progress.resourceModel.serialize()).toMatchObject({ ...request.desiredResourceState, ResourceId: 'Z123456789012345678/us-east-1/v-12345678901234567' });
+    });
+
+    test('update operation successful - vpc association', async () => {
+        const request = fixtureMap.get(Action.Update);
+        const progress = await resource.testEntrypoint({ ...testEntrypointPayload, action: Action.Update, request }, null);
+        expect(progress).toMatchObject({ status: OperationStatus.Success, message: '', callbackDelaySeconds: 0 });
+        expect(progress.resourceModel.serialize()).toMatchObject(request.desiredResourceState);
+    });
+
+    test('delete operation successful - vpc association', async () => {
+        const request = fixtureMap.get(Action.Delete);
+        const progress = await resource.testEntrypoint({ ...testEntrypointPayload, action: Action.Delete, request }, null);
+        expect(progress).toMatchObject({ status: OperationStatus.Success, message: '', callbackDelaySeconds: 0 });
+        expect(progress.resourceModel).toBeNull();
+    });
+
+    test('all operations fail without session - vpc association', async () => {
+        expect.assertions(fixtureMap.size);
+        spySession.mockReturnValue(null);
+        for (const [action, request] of fixtureMap) {
+            const progress = await resource.testEntrypoint({ ...testEntrypointPayload, action, request }, null);
+            console.log(JSON.stringify(progress));
+            expect(progress.errorCode).toBe(exceptions.InvalidCredentials.name);
+        }
+    });
+});

--- a/route53/vpc-association/community-route53-vpcassociation.json
+++ b/route53/vpc-association/community-route53-vpcassociation.json
@@ -1,0 +1,83 @@
+{
+    "typeName": "Community::Route53::VPCAssociation",
+    "description": "Associates an Amazon VPC with a private hosted zone.",
+    "sourceUrl": "https://github.com/aws-cloudformation/aws-cloudformation-rpdk.git",
+    "definitions": {
+        "VPC": {
+            "description": "A complex type that contains information about the VPC that you want to associate with a private hosted zone.",
+            "type": "object",
+            "properties": {
+                "VPCRegion": {
+                    "type": "string",
+                    "description": "The region that an Amazon VPC was created in."
+                },
+                "VPCId": {
+                    "type": "string",
+                    "description": "The ID of an Amazon VPC.",
+                    "maxLength": 32
+                }
+            },
+            "required": [
+                "VPCRegion",
+                "VPCId"
+            ],
+            "additionalProperties": false
+        }
+    },
+    "properties": {
+        "ResourceId": {
+            "type": "string",
+            "description": "The ID of this resource."
+        },
+        "HostedZoneId": {
+            "description": "The ID of the private hosted zone that you want to associate an Amazon VPC with.\n\nNote that you can't associate a VPC with a hosted zone that doesn't have an existing VPC association.",
+            "type": "string"
+        },
+        "VPC": {
+            "$ref": "#/definitions/VPC"
+        }
+    },
+    "additionalProperties": false,
+    "createOnlyProperties": [
+        "/properties/HostedZoneId",
+        "/properties/VPC"
+    ],
+    "replacementStrategy": "create_then_delete",
+    "required": [
+        "HostedZoneId",
+        "VPC"
+    ],
+    "readOnlyProperties": [
+        "/properties/ResourceId"
+    ],
+    "primaryIdentifier": [
+        "/properties/ResourceId"
+    ],
+    "handlers": {
+        "create": {
+            "permissions": [
+                "route53:AssociateVPCWithHostedZone",
+                "ec2:DescribeVpcs"
+            ]
+        },
+        "read": {
+            "permissions": []
+        },
+        "update": {
+            "permissions": [
+                "route53:DisassociateVPCFromHostedZone",
+                "route53:AssociateVPCWithHostedZone",
+                "ec2:DescribeVpcs"
+            ]
+        },
+        "delete": {
+            "permissions": [
+                "route53:DisassociateVPCFromHostedZone",
+                "ec2:DescribeVpcs"
+            ]
+        },
+        "list": {
+            "permissions": []
+        }
+    }
+}

--- a/route53/vpc-association/docs/README.md
+++ b/route53/vpc-association/docs/README.md
@@ -1,0 +1,69 @@
+# Community::Route53::VPCAssociation
+
+Associates an Amazon VPC with a private hosted zone.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "Type" : "Community::Route53::VPCAssociation",
+    "Properties" : {
+        "<a href="#hostedzoneid" title="HostedZoneId">HostedZoneId</a>" : <i>String</i>,
+        "<a href="#vpc" title="VPC">VPC</a>" : <i><a href="vpc.md">VPC</a></i>
+    }
+}
+</pre>
+
+### YAML
+
+<pre>
+Type: Community::Route53::VPCAssociation
+Properties:
+    <a href="#hostedzoneid" title="HostedZoneId">HostedZoneId</a>: <i>String</i>
+    <a href="#vpc" title="VPC">VPC</a>: <i><a href="vpc.md">VPC</a></i>
+</pre>
+
+## Properties
+
+#### HostedZoneId
+
+The ID of the private hosted zone that you want to associate an Amazon VPC with.
+
+Note that you can't associate a VPC with a hosted zone that doesn't have an existing VPC association.
+
+_Required_: Yes
+
+_Type_: String
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### VPC
+
+A complex type that contains information about the VPC that you want to associate with a private hosted zone.
+
+_Required_: Yes
+
+_Type_: <a href="vpc.md">VPC</a>
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+## Return Values
+
+### Ref
+
+When you pass the logical ID of this resource to the intrinsic `Ref` function, Ref returns the ResourceId.
+
+### Fn::GetAtt
+
+The `Fn::GetAtt` intrinsic function returns a value for a specified attribute of this type. The following are the available attributes and sample return values.
+
+For more information about using the `Fn::GetAtt` intrinsic function, see [Fn::GetAtt](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-getatt.html).
+
+#### ResourceId
+
+The ID of this resource.
+

--- a/route53/vpc-association/docs/vpc.md
+++ b/route53/vpc-association/docs/vpc.md
@@ -1,0 +1,48 @@
+# Community::Route53::VPCAssociation VPC
+
+A complex type that contains information about the VPC that you want to associate with a private hosted zone.
+
+## Syntax
+
+To declare this entity in your AWS CloudFormation template, use the following syntax:
+
+### JSON
+
+<pre>
+{
+    "<a href="#vpcregion" title="VPCRegion">VPCRegion</a>" : <i>String</i>,
+    "<a href="#vpcid" title="VPCId">VPCId</a>" : <i>String</i>
+}
+</pre>
+
+### YAML
+
+<pre>
+<a href="#vpcregion" title="VPCRegion">VPCRegion</a>: <i>String</i>
+<a href="#vpcid" title="VPCId">VPCId</a>: <i>String</i>
+</pre>
+
+## Properties
+
+#### VPCRegion
+
+The region that an Amazon VPC was created in.
+
+_Required_: Yes
+
+_Type_: String
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+
+#### VPCId
+
+The ID of an Amazon VPC.
+
+_Required_: Yes
+
+_Type_: String
+
+_Maximum_: <code>32</code>
+
+_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+

--- a/route53/vpc-association/jest.config.js
+++ b/route53/vpc-association/jest.config.js
@@ -1,0 +1,10 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
+const base = require('../../jest.config.base.js');
+const package = require('./package');
+
+module.exports = {
+    ...base,
+    displayName: package.name,
+    name: package.name,
+};

--- a/route53/vpc-association/package-lock.json
+++ b/route53/vpc-association/package-lock.json
@@ -1,0 +1,969 @@
+{
+    "name": "community-route53-vpcassociation",
+    "version": "0.1.0",
+    "lockfileVersion": 2,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "community-route53-vpcassociation",
+            "version": "0.1.0",
+            "dependencies": {
+                "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "^1.0.1",
+                "aws-resource-providers-common": "https://github.com/org-formation/aws-resource-providers/releases/download/common-0.4.0/aws-resource-providers-common-0.4.0.tgz",
+                "class-transformer": "0.3.1"
+            },
+            "devDependencies": {
+                "@types/node": "^12.0.0",
+                "typescript": "^4.1.2"
+            },
+            "optionalDependencies": {
+                "aws-sdk": "^2.656.0"
+            }
+        },
+        "node_modules/@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib/-/cloudformation-cli-typescript-lib-1.0.1.tgz",
+            "integrity": "sha512-degYITXnwEJbkUyWBTRr6dSoly9GKetpvhJ+PB04IX7vKe9+kJcCC0C+fiKSag5e3dLWamf1x6O2jWdgHkRu2Q==",
+            "dependencies": {
+                "@org-formation/tombok": "^0.0.1",
+                "autobind-decorator": "^2.4.0",
+                "class-transformer": "^0.3.1",
+                "reflect-metadata": "^0.1.13",
+                "string.prototype.replaceall": "^1.0.3",
+                "uuid": "^7.0.2"
+            },
+            "engines": {
+                "node": ">=12.0.0",
+                "npm": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "aws-sdk": "^2.712.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-sdk": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@org-formation/tombok": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@org-formation/tombok/-/tombok-0.0.1.tgz",
+            "integrity": "sha512-6F0zitevY+H3VT3MVsAo4JFlDl5kfqnhGLUwXNc652/HYEBzMru5iLkTIF6+cp/lgvTWxQJQJzH4yoYja2f9Pg==",
+            "engines": {
+                "node": ">=10.0.0",
+                "npm": ">=5.6.0"
+            }
+        },
+        "node_modules/@types/node": {
+            "version": "12.20.14",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.14.tgz",
+            "integrity": "sha512-iFJOS5Q470FF+r4Ol2pSley7/wCNVqf+jgjhtxLLaJcDs+To2iCxlXIkJXrGLD9w9G/oJ9ibySu7z92DCwr7Pg==",
+            "dev": true
+        },
+        "node_modules/autobind-decorator": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/autobind-decorator/-/autobind-decorator-2.4.0.tgz",
+            "integrity": "sha512-OGYhWUO72V6DafbF8PM8rm3EPbfuyMZcJhtm5/n26IDwO18pohE4eNazLoCGhPiXOCD0gEGmrbU3849QvM8bbw==",
+            "engines": {
+                "node": ">=8.10",
+                "npm": ">=6.4.1"
+            }
+        },
+        "node_modules/aws-resource-providers-common": {
+            "version": "0.4.0",
+            "resolved": "https://github.com/org-formation/aws-resource-providers/releases/download/common-0.4.0/aws-resource-providers-common-0.4.0.tgz",
+            "integrity": "sha512-N23pLEGSMMVcckiupO0DRBkLuwqhGvbxppz/bdQG4shq6neGh6T8aoO5WkU5bvJvvw6JIDrWw5Bbf5rElOfL8A==",
+            "license": "MIT",
+            "dependencies": {
+                "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "^1.0.1"
+            },
+            "peerDependencies": {
+                "aws-sdk": "^2.656.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-sdk": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/aws-sdk": {
+            "version": "2.920.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.920.0.tgz",
+            "integrity": "sha512-tbMZ/Y2rRo6R6TTBODJXTiil+MXaoT6Qzotws3yvI1IWGpYxKo7N/3L06XB8ul8tCG0TigxIOY70SMICM70Ppg==",
+            "hasInstallScript": true,
+            "optional": true,
+            "dependencies": {
+                "buffer": "4.9.2",
+                "events": "1.1.1",
+                "ieee754": "1.1.13",
+                "jmespath": "0.15.0",
+                "querystring": "0.2.0",
+                "sax": "1.2.1",
+                "url": "0.10.3",
+                "uuid": "3.3.2",
+                "xml2js": "0.4.19"
+            },
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/aws-sdk/node_modules/uuid": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+            "optional": true,
+            "bin": {
+                "uuid": "bin/uuid"
+            }
+        },
+        "node_modules/base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "optional": true
+        },
+        "node_modules/buffer": {
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+            "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+            "optional": true,
+            "dependencies": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
+            }
+        },
+        "node_modules/call-bind": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "dependencies": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/class-transformer": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.3.1.tgz",
+            "integrity": "sha512-cKFwohpJbuMovS8xVLmn8N2AUbAuc8pVo4zEfsUVo8qgECOogns1WVk/FkOZoxhOPTyTYFckuoH+13FO+MQ8GA=="
+        },
+        "node_modules/define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dependencies": {
+                "object-keys": "^1.0.12"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-abstract": {
+            "version": "1.18.3",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+            "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.2",
+                "is-callable": "^1.2.3",
+                "is-negative-zero": "^2.0.1",
+                "is-regex": "^1.1.3",
+                "is-string": "^1.0.6",
+                "object-inspect": "^1.10.3",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.2",
+                "string.prototype.trimend": "^1.0.4",
+                "string.prototype.trimstart": "^1.0.4",
+                "unbox-primitive": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/es-to-primitive": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "dependencies": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/events": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+            "optional": true,
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+        },
+        "node_modules/get-intrinsic": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+            "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+            "dependencies": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dependencies": {
+                "function-bind": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4.0"
+            }
+        },
+        "node_modules/has-bigints": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+            "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-symbols": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+            "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/ieee754": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+            "optional": true
+        },
+        "node_modules/is-bigint": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+            "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-boolean-object": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+            "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
+            "dependencies": {
+                "call-bind": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-callable": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+            "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-date-object": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+            "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-negative-zero": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+            "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-number-object": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+            "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-regex": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+            "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-symbols": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-string": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+            "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-symbol": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+            "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+            "dependencies": {
+                "has-symbols": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "optional": true
+        },
+        "node_modules/jmespath": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+            "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+            "optional": true,
+            "engines": {
+                "node": ">= 0.6.0"
+            }
+        },
+        "node_modules/object-inspect": {
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+            "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/object.assign": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+            "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+            "dependencies": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3",
+                "has-symbols": "^1.0.1",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/punycode": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+            "optional": true
+        },
+        "node_modules/querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "optional": true,
+            "engines": {
+                "node": ">=0.4.x"
+            }
+        },
+        "node_modules/reflect-metadata": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+            "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+        },
+        "node_modules/sax": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+            "optional": true
+        },
+        "node_modules/string.prototype.replaceall": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/string.prototype.replaceall/-/string.prototype.replaceall-1.0.5.tgz",
+            "integrity": "sha512-YUjdWElI9pgKo7mrPOMKHFZxcAa0v1uqoJkMHtlJW63rMkPLkQH71ao2XNkKY2ksHKHC8ZUFwNjN9Vry+QyCvg==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.18.0-next.2",
+                "get-intrinsic": "^1.1.1",
+                "has-symbols": "^1.0.1",
+                "is-regex": "^1.1.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/string.prototype.trimend": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+            "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/string.prototype.trimstart": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+            "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+            "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/unbox-primitive": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+            "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+            "dependencies": {
+                "function-bind": "^1.1.1",
+                "has-bigints": "^1.0.1",
+                "has-symbols": "^1.0.2",
+                "which-boxed-primitive": "^1.0.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/url": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+            "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+            "optional": true,
+            "dependencies": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            }
+        },
+        "node_modules/uuid": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+            "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
+        "node_modules/which-boxed-primitive": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+            "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+            "dependencies": {
+                "is-bigint": "^1.0.1",
+                "is-boolean-object": "^1.1.0",
+                "is-number-object": "^1.0.4",
+                "is-string": "^1.0.5",
+                "is-symbol": "^1.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/xml2js": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "optional": true,
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
+            }
+        },
+        "node_modules/xmlbuilder": {
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+            "optional": true,
+            "engines": {
+                "node": ">=4.0"
+            }
+        }
+    },
+    "dependencies": {
+        "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib/-/cloudformation-cli-typescript-lib-1.0.1.tgz",
+            "integrity": "sha512-degYITXnwEJbkUyWBTRr6dSoly9GKetpvhJ+PB04IX7vKe9+kJcCC0C+fiKSag5e3dLWamf1x6O2jWdgHkRu2Q==",
+            "requires": {
+                "@org-formation/tombok": "^0.0.1",
+                "autobind-decorator": "^2.4.0",
+                "class-transformer": "^0.3.1",
+                "reflect-metadata": "^0.1.13",
+                "string.prototype.replaceall": "^1.0.3",
+                "uuid": "^7.0.2"
+            }
+        },
+        "@org-formation/tombok": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@org-formation/tombok/-/tombok-0.0.1.tgz",
+            "integrity": "sha512-6F0zitevY+H3VT3MVsAo4JFlDl5kfqnhGLUwXNc652/HYEBzMru5iLkTIF6+cp/lgvTWxQJQJzH4yoYja2f9Pg=="
+        },
+        "@types/node": {
+            "version": "12.20.14",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.14.tgz",
+            "integrity": "sha512-iFJOS5Q470FF+r4Ol2pSley7/wCNVqf+jgjhtxLLaJcDs+To2iCxlXIkJXrGLD9w9G/oJ9ibySu7z92DCwr7Pg==",
+            "dev": true
+        },
+        "autobind-decorator": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/autobind-decorator/-/autobind-decorator-2.4.0.tgz",
+            "integrity": "sha512-OGYhWUO72V6DafbF8PM8rm3EPbfuyMZcJhtm5/n26IDwO18pohE4eNazLoCGhPiXOCD0gEGmrbU3849QvM8bbw=="
+        },
+        "aws-resource-providers-common": {
+            "version": "https://github.com/org-formation/aws-resource-providers/releases/download/common-0.4.0/aws-resource-providers-common-0.4.0.tgz",
+            "integrity": "sha512-N23pLEGSMMVcckiupO0DRBkLuwqhGvbxppz/bdQG4shq6neGh6T8aoO5WkU5bvJvvw6JIDrWw5Bbf5rElOfL8A==",
+            "requires": {
+                "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "^1.0.1"
+            }
+        },
+        "aws-sdk": {
+            "version": "2.920.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.920.0.tgz",
+            "integrity": "sha512-tbMZ/Y2rRo6R6TTBODJXTiil+MXaoT6Qzotws3yvI1IWGpYxKo7N/3L06XB8ul8tCG0TigxIOY70SMICM70Ppg==",
+            "optional": true,
+            "requires": {
+                "buffer": "4.9.2",
+                "events": "1.1.1",
+                "ieee754": "1.1.13",
+                "jmespath": "0.15.0",
+                "querystring": "0.2.0",
+                "sax": "1.2.1",
+                "url": "0.10.3",
+                "uuid": "3.3.2",
+                "xml2js": "0.4.19"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "3.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+                    "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+                    "optional": true
+                }
+            }
+        },
+        "base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "optional": true
+        },
+        "buffer": {
+            "version": "4.9.2",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+            "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+            "optional": true,
+            "requires": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
+            }
+        },
+        "call-bind": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+            }
+        },
+        "class-transformer": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.3.1.tgz",
+            "integrity": "sha512-cKFwohpJbuMovS8xVLmn8N2AUbAuc8pVo4zEfsUVo8qgECOogns1WVk/FkOZoxhOPTyTYFckuoH+13FO+MQ8GA=="
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "requires": {
+                "object-keys": "^1.0.12"
+            }
+        },
+        "es-abstract": {
+            "version": "1.18.3",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+            "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.2",
+                "is-callable": "^1.2.3",
+                "is-negative-zero": "^2.0.1",
+                "is-regex": "^1.1.3",
+                "is-string": "^1.0.6",
+                "object-inspect": "^1.10.3",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.2",
+                "string.prototype.trimend": "^1.0.4",
+                "string.prototype.trimstart": "^1.0.4",
+                "unbox-primitive": "^1.0.1"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
+        "events": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+            "optional": true
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+        },
+        "get-intrinsic": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+            "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1"
+            }
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
+        "has-bigints": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+            "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+        },
+        "has-symbols": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+            "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+        },
+        "ieee754": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+            "optional": true
+        },
+        "is-bigint": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+            "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA=="
+        },
+        "is-boolean-object": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+            "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
+            "requires": {
+                "call-bind": "^1.0.2"
+            }
+        },
+        "is-callable": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+            "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
+        },
+        "is-date-object": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+            "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A=="
+        },
+        "is-negative-zero": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+            "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+        },
+        "is-number-object": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+            "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw=="
+        },
+        "is-regex": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+            "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-symbols": "^1.0.2"
+            }
+        },
+        "is-string": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+            "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w=="
+        },
+        "is-symbol": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+            "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+            "requires": {
+                "has-symbols": "^1.0.2"
+            }
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "optional": true
+        },
+        "jmespath": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+            "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+            "optional": true
+        },
+        "object-inspect": {
+            "version": "1.10.3",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+            "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        },
+        "object.assign": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+            "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+            "requires": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3",
+                "has-symbols": "^1.0.1",
+                "object-keys": "^1.1.1"
+            }
+        },
+        "punycode": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+            "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+            "optional": true
+        },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "optional": true
+        },
+        "reflect-metadata": {
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+            "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+        },
+        "sax": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+            "optional": true
+        },
+        "string.prototype.replaceall": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/string.prototype.replaceall/-/string.prototype.replaceall-1.0.5.tgz",
+            "integrity": "sha512-YUjdWElI9pgKo7mrPOMKHFZxcAa0v1uqoJkMHtlJW63rMkPLkQH71ao2XNkKY2ksHKHC8ZUFwNjN9Vry+QyCvg==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.18.0-next.2",
+                "get-intrinsic": "^1.1.1",
+                "has-symbols": "^1.0.1",
+                "is-regex": "^1.1.2"
+            }
+        },
+        "string.prototype.trimend": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+            "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            }
+        },
+        "string.prototype.trimstart": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+            "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            }
+        },
+        "typescript": {
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
+            "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+            "dev": true
+        },
+        "unbox-primitive": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+            "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has-bigints": "^1.0.1",
+                "has-symbols": "^1.0.2",
+                "which-boxed-primitive": "^1.0.2"
+            }
+        },
+        "url": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+            "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+            "optional": true,
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            }
+        },
+        "uuid": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+            "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
+        },
+        "which-boxed-primitive": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+            "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+            "requires": {
+                "is-bigint": "^1.0.1",
+                "is-boolean-object": "^1.1.0",
+                "is-number-object": "^1.0.4",
+                "is-string": "^1.0.5",
+                "is-symbol": "^1.0.3"
+            }
+        },
+        "xml2js": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "optional": true,
+            "requires": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
+            }
+        },
+        "xmlbuilder": {
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+            "optional": true
+        }
+    }
+}

--- a/route53/vpc-association/package.json
+++ b/route53/vpc-association/package.json
@@ -1,0 +1,35 @@
+{
+    "name": "community-route53-vpcassociation",
+    "version": "0.1.0",
+    "description": "AWS custom resource provider named Community::Route53::VPCAssociation.",
+    "private": true,
+    "main": "dist/handlers.js",
+    "files": [
+        "dist"
+    ],
+    "scripts": {
+        "build": "npx tsc",
+        "fixrolepath": "sed 's/Path: \\\"\\/\\\"/Path: \\\"\\/community-types\\/\\\"/g' resource-role.yaml > tmp.txt && mv tmp.txt resource-role.yaml",
+        "prepack": "cfn generate && npm run build && npm run fixrolepath",
+        "submit": "npm run prepack && cfn submit -vv --region us-east-1 --set-default",
+        "package": "npm run prepack && cfn submit --dry-run -vv && cp ${npm_package_name}.zip ${npm_package_name}-${npm_package_version}.zip",
+        "version": "npm run package && aws s3 cp ${npm_package_name}-${npm_package_version}.zip s3://community-resource-provider-catalog/${npm_package_name}-${npm_package_version}.zip && aws s3 cp resource-role.yaml s3://community-resource-provider-catalog/${npm_package_name}-resource-role-${npm_package_version}.yml",
+        "test": "npx jest",
+        "test:integration": "npx npm-run-all -p -r samstart cfntest",
+        "cfntest": "cfn test -vv >> cfn.log",
+        "samstart": "sam local start-lambda -l sam.log",
+        "validate": "cfn validate"
+    },
+    "dependencies": {
+        "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "^1.0.1",
+        "aws-resource-providers-common": "https://github.com/org-formation/aws-resource-providers/releases/download/common-0.4.0/aws-resource-providers-common-0.4.0.tgz",
+        "class-transformer": "0.3.1"
+    },
+    "devDependencies": {
+        "@types/node": "^12.0.0",
+        "typescript": "^4.1.2"
+    },
+    "optionalDependencies": {
+        "aws-sdk": "^2.656.0"
+    }
+}

--- a/route53/vpc-association/resource-role.yaml
+++ b/route53/vpc-association/resource-role.yaml
@@ -1,0 +1,33 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  This CloudFormation template creates a role assumed by CloudFormation
+  during CRUDL operations to mutate resources on behalf of the customer.
+
+Resources:
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      MaxSessionDuration: 8400
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: resources.cloudformation.amazonaws.com
+            Action: sts:AssumeRole
+      Path: "/community-types/"
+      Policies:
+        - PolicyName: ResourceTypePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                - "ec2:DescribeVpcs"
+                - "route53:AssociateVPCWithHostedZone"
+                - "route53:DisassociateVPCFromHostedZone"
+                Resource: "*"
+Outputs:
+  ExecutionRoleArn:
+    Value:
+      Fn::GetAtt: ExecutionRole.Arn

--- a/route53/vpc-association/src/handlers.ts
+++ b/route53/vpc-association/src/handlers.ts
@@ -1,0 +1,66 @@
+import { Route53 } from 'aws-sdk';
+import { commonAws, HandlerArgs } from 'aws-resource-providers-common';
+import { Action, BaseResource, exceptions, handlerEvent, Logger } from '@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib';
+
+import { ResourceModel, VPC } from './models';
+
+class Resource extends BaseResource<ResourceModel> {
+    private async createVpcAssociation(action: Action, service: Route53, logger: Logger, model: ResourceModel): Promise<ResourceModel> {
+        const request: Route53.AssociateVPCWithHostedZoneRequest = {
+            HostedZoneId: model.hostedZoneId,
+            VPC: {
+                VPCId: model.vPC.vPCId,
+                VPCRegion: model.vPC.vPCRegion,
+            },
+        };
+        logger.log({ action, message: 'before invoke associateVPCWithHostedZone', request });
+        const response = await service.associateVPCWithHostedZone(request).promise();
+        logger.log({ action, message: 'after invoke associateVPCWithHostedZone', response });
+        logger.log({ action, message: 'done', model });
+        model.resourceId = `${model.hostedZoneId}/${model.vPC.vPCRegion}/${model.vPC.vPCId}`;
+        return model;
+    }
+
+    private async deleteVpcAssociation(action: Action, service: Route53, logger: Logger, model: ResourceModel): Promise<null> {
+        const request: Route53.DisassociateVPCFromHostedZoneRequest = {
+            HostedZoneId: model.hostedZoneId,
+            VPC: {
+                VPCId: model.vPC.vPCId,
+                VPCRegion: model.vPC.vPCRegion,
+            },
+        };
+        logger.log({ action, message: 'before invoke disassociateVPCFromHostedZone', request });
+        const response = await service.disassociateVPCFromHostedZone(request).promise();
+        logger.log({ action, message: 'after invoke disassociateVPCFromHostedZone', response });
+        logger.log({ action, message: 'done', model });
+        return null;
+    }
+
+    @handlerEvent(Action.Create)
+    @commonAws({ serviceName: 'Route53', debug: true })
+    public async create(action: Action, args: HandlerArgs<ResourceModel>, service: Route53, model: ResourceModel): Promise<ResourceModel> {
+        if (model.resourceId) throw new exceptions.InvalidRequest('Read only property [ResourceId] cannot be provided by the user.');
+        return this.createVpcAssociation(action, service, args.logger, model);
+    }
+
+    @handlerEvent(Action.Update)
+    @commonAws({ serviceName: 'Route53', debug: true })
+    public async update(action: Action, args: HandlerArgs<ResourceModel>, service: Route53, model: ResourceModel): Promise<ResourceModel> {
+        if (model.resourceId) throw new exceptions.InvalidRequest('Read only property [ResourceId] cannot be provided by the user.');
+        return this.createVpcAssociation(action, service, args.logger, model);
+    }
+
+    @handlerEvent(Action.Delete)
+    @commonAws({ serviceName: 'Route53', debug: true })
+    public async delete(action: Action, args: HandlerArgs<ResourceModel>, service: Route53, model: ResourceModel): Promise<null> {
+        return this.deleteVpcAssociation(action, service, args.logger, model);
+    }
+}
+
+export const resource = new Resource(ResourceModel.TYPE_NAME, ResourceModel);
+
+// Entrypoint for production usage after registered in CloudFormation
+export const entrypoint = resource.entrypoint;
+
+// Entrypoint used for local testing
+export const testEntrypoint = resource.testEntrypoint;

--- a/route53/vpc-association/src/models.ts
+++ b/route53/vpc-association/src/models.ts
@@ -1,0 +1,79 @@
+// This is a generated file. Modifications will be overwritten.
+import { BaseModel, Dict, integer, Integer, Optional, transformValue } from '@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib';
+import { Exclude, Expose, Type, Transform } from 'class-transformer';
+
+export class ResourceModel extends BaseModel {
+    ['constructor']: typeof ResourceModel;
+
+    @Exclude()
+    public static readonly TYPE_NAME: string = 'Community::Route53::VPCAssociation';
+
+    @Exclude()
+    protected readonly IDENTIFIER_KEY_RESOURCEID: string = '/properties/ResourceId';
+
+    @Expose({ name: 'ResourceId' })
+    @Transform(
+        (value: any, obj: any) =>
+            transformValue(String, 'resourceId', value, obj, []),
+        {
+            toClassOnly: true,
+        }
+    )
+    resourceId?: Optional<string>;
+    @Expose({ name: 'HostedZoneId' })
+    @Transform(
+        (value: any, obj: any) =>
+            transformValue(String, 'hostedZoneId', value, obj, []),
+        {
+            toClassOnly: true,
+        }
+    )
+    hostedZoneId?: Optional<string>;
+    @Expose({ name: 'VPC' })
+    @Type(() => VPC)
+    vPC?: Optional<VPC>;
+
+    @Exclude()
+    public getPrimaryIdentifier(): Dict {
+        const identifier: Dict = {};
+        if (this.resourceId != null) {
+            identifier[this.IDENTIFIER_KEY_RESOURCEID] = this.resourceId;
+        }
+
+        // only return the identifier if it can be used, i.e. if all components are present
+        return Object.keys(identifier).length === 1 ? identifier : null;
+    }
+
+    @Exclude()
+    public getAdditionalIdentifiers(): Array<Dict> {
+        const identifiers: Array<Dict> = new Array<Dict>();
+        // only return the identifiers if any can be used
+        return identifiers.length === 0 ? null : identifiers;
+    }
+}
+
+export class VPC extends BaseModel {
+    ['constructor']: typeof VPC;
+
+
+    @Expose({ name: 'VPCRegion' })
+    @Transform(
+        (value: any, obj: any) =>
+            transformValue(String, 'vPCRegion', value, obj, []),
+        {
+            toClassOnly: true,
+        }
+    )
+    vPCRegion?: Optional<string>;
+    @Expose({ name: 'VPCId' })
+    @Transform(
+        (value: any, obj: any) =>
+            transformValue(String, 'vPCId', value, obj, []),
+        {
+            toClassOnly: true,
+        }
+    )
+    vPCId?: Optional<string>;
+
+}
+

--- a/route53/vpc-association/template.yml
+++ b/route53/vpc-association/template.yml
@@ -1,0 +1,24 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: AWS SAM template for the Community::Route53::VPCAssociation resource type
+
+Globals:
+  Function:
+    Timeout: 180  # docker start-up times can be long for SAM CLI
+    MemorySize: 256
+
+Resources:
+  TestEntrypoint:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: dist/handlers.testEntrypoint
+      Runtime: nodejs12.x
+      CodeUri: ./
+
+  TypeFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: dist/handlers.entrypoint
+      Runtime: nodejs12.x
+      CodeUri: ./
+

--- a/route53/vpc-association/tsconfig.json
+++ b/route53/vpc-association/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "dist"
+    },
+    "include": [
+        "src/**/*.ts"
+    ]
+}


### PR DESCRIPTION
Adds two new resource providers: `Community::Route53::VPCAssociationAuthorization` and `Community::Route53::VPCAssociation`, to help associate Route53 private hosted zones with VPCs across accounts within CloudFormation

There is one issue with the current implementation that I'm not sure how you'd work around. When calling the `route53.associateVpcWithHostedZone` api, a Route53 "change" is returned. It seems like the association process is asynchronous, and you'll have to poll with the `route53.getChange` api until the returned `Status` is `INSYNC`. Unfortunately, if you're doing this across accounts, the `getChange` api must be called in the account with the private hosted zone, where the `associateVpcWithHostedZone` api must be called in the account with the vpc, and without hacking in a cross-account role, I don't think we can do that, so at this point in time the `VPCAssociation` resource is asynchronous. I haven't dug into the actual ramifications of this resource provider being asynchronous, but no IaC dependency on this resource comes to mind, the eventual consistency works in my testing with a vpc associating with a few cross account hosted zones

This was my first time working with custom resource providers, let me know if anything is off, thanks!