### PR TITLE
fix: cfn validate schema warnings

### DIFF
--- a/iam/password-policy/community-iam-passwordpolicy.json
+++ b/iam/password-policy/community-iam-passwordpolicy.json
@@ -66,9 +66,6 @@
     },
     "additionalProperties": false,
     "required": [],
-    "createOnlyProperties": [
-        "/properties/ResourceId"
-    ],
     "readOnlyProperties": [
         "/properties/ResourceId",
         "/properties/ExpirePasswords"

--- a/security-hub/action-target/community-securityhub-actiontarget.json
+++ b/security-hub/action-target/community-securityhub-actiontarget.json
@@ -10,7 +10,7 @@
             "description": "The Amazon Resource Name (ARN) of the custom action target.",
             "minLength": 25,
             "maxLength": 256,
-            "pattern": "^arn:aws:securityhub:[A-Za-z0-9-]{1,64}:[0-9]{12}:action/custom/.+$"
+            "pattern": "^arn:aws[-a-z]*:securityhub:[A-Za-z0-9-]{1,64}:[0-9]{12}:action/custom/.+$"
         },
         "Id": {
             "type": "string",


### PR DESCRIPTION
[`readOnlyProperties cannot be specified by customers and should not overlap with writeOnlyProperties, createOnlyProperties, or required: {'/properties/ResourceId'}`](https://github.com/aws-cloudformation/cloudformation-resource-schema/#resource-semantics)

[`Don't hardcode the aws partition in ARN patterns: ^arn:aws:securityhub:[A-Za-z0-9-]{1,64}:[0-9]{12}:action/custom/.+$`](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-syntax)
