### PR TITLE
fix: too many requests on support-level rp

### DIFF
--- a/support/support-level/package.json
+++ b/support/support-level/package.json
@@ -1,6 +1,6 @@
 {
     "name": "community-support-supportlevel",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "AWS custom resource provider named Community::Support::SupportLevel.",
     "main": "dist/handlers.js",
     "files": [

--- a/support/support-level/resource-role.yaml
+++ b/support/support-level/resource-role.yaml
@@ -15,7 +15,7 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
-      Path: "/"
+      Path: "/community-types/"
       Policies:
         - PolicyName: ResourceTypePolicy
           PolicyDocument:

--- a/support/support-level/src/handlers.ts
+++ b/support/support-level/src/handlers.ts
@@ -31,7 +31,10 @@ async function checkContextIsOrganizationMasterAccount(args: HandlerArgs<Resourc
     try {
         const organizationsClient = args.session.client('Organizations', { region: 'us-east-1' }) as Organizations;
         await organizationsClient.describeOrganization().promise();
-    } catch (err) {
+    } catch (err: any) {
+        if ('code' in err && err.code === 'TooManyRequestsException') {
+            return;
+        }
         throw new exceptions.InvalidRequest(`Account does not seem to be the master account of an AWS Organization.\n${err}`);
     }
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/org-formation/aws-resource-providers/issues/100

*Description of changes:*

fixes the too many requests error by using this as al alternative indication the RP is running in the master account
