### PR TITLE
chore: unsuppress findings for rule that got enabled

### DIFF
--- a/security-hub/standards-control/community-securityhub-standardscontrol.json
+++ b/security-hub/standards-control/community-securityhub-standardscontrol.json
@@ -23,6 +23,9 @@
         "ControlId": {
             "type": "string"
         },
+        "SuppressionsUpdatedBy": {
+            "type": "string"
+        },
         "SuppressCurrentFindingsOnDisabled": {
             "type": "boolean"
         },

--- a/security-hub/standards-control/docs/README.md
+++ b/security-hub/standards-control/docs/README.md
@@ -14,6 +14,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
     "Properties" : {
         "<a href="#standardcode" title="StandardCode">StandardCode</a>" : <i>String</i>,
         "<a href="#controlid" title="ControlId">ControlId</a>" : <i>String</i>,
+        "<a href="#suppressionsupdatedby" title="SuppressionsUpdatedBy">SuppressionsUpdatedBy</a>" : <i>String</i>,
         "<a href="#suppresscurrentfindingsondisabled" title="SuppressCurrentFindingsOnDisabled">SuppressCurrentFindingsOnDisabled</a>" : <i>Boolean</i>,
         "<a href="#controlstatus" title="ControlStatus">ControlStatus</a>" : <i>String</i>,
         "<a href="#disabledreason" title="DisabledReason">DisabledReason</a>" : <i>String</i>
@@ -28,6 +29,7 @@ Type: Community::SecurityHub::StandardsControl
 Properties:
     <a href="#standardcode" title="StandardCode">StandardCode</a>: <i>String</i>
     <a href="#controlid" title="ControlId">ControlId</a>: <i>String</i>
+    <a href="#suppressionsupdatedby" title="SuppressionsUpdatedBy">SuppressionsUpdatedBy</a>: <i>String</i>
     <a href="#suppresscurrentfindingsondisabled" title="SuppressCurrentFindingsOnDisabled">SuppressCurrentFindingsOnDisabled</a>: <i>Boolean</i>
     <a href="#controlstatus" title="ControlStatus">ControlStatus</a>: <i>String</i>
     <a href="#disabledreason" title="DisabledReason">DisabledReason</a>: <i>String</i>
@@ -43,11 +45,19 @@ _Type_: String
 
 _Allowed Values_: <code>CIS1.4</code> | <code>CIS1.2</code> | <code>CIS</code> | <code>PCIDSS</code> | <code>AFSBP</code>
 
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### ControlId
 
 _Required_: Yes
+
+_Type_: String
+
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
+
+#### SuppressionsUpdatedBy
+
+_Required_: No
 
 _Type_: String
 

--- a/security-hub/standards-control/package.json
+++ b/security-hub/standards-control/package.json
@@ -1,6 +1,6 @@
 {
     "name": "community-securityhub-standardscontrol",
-    "version": "0.2.2",
+    "version": "0.2.5",
     "description": "AWS custom resource provider named Community::SecurityHub::StandardsControl.",
     "private": true,
     "main": "dist/handlers.js",

--- a/security-hub/standards-control/src/models.ts
+++ b/security-hub/standards-control/src/models.ts
@@ -38,6 +38,15 @@ export class ResourceModel extends BaseModel {
         }
     )
     controlId?: Optional<string>;
+    @Expose({ name: 'SuppressionsUpdatedBy' })
+    @Transform(
+        (value: any, obj: any) =>
+            transformValue(String, 'suppressionsUpdatedBy', value, obj, []),
+        {
+            toClassOnly: true,
+        }
+    )
+    suppressionsUpdatedBy?: Optional<string>;
     @Expose({ name: 'SuppressCurrentFindingsOnDisabled' })
     @Transform(
         (value: any, obj: any) =>


### PR DESCRIPTION
this modifies the StandardsControl resource to 
1) add a note to the findings it suppresses
2) unsuppress findings if a rule gets enabled

as previous versions did not get a note it will unsuppress all findings against the control that got enabled.
if the findings got suppressed by this version (or higher) it will only unsuppress findings it did suppress itself (using NoteUpdatedBy)