### PR TITLE
Add the required `ResourceId` property to example.yml

### DIFF
--- a/organizations/enable-aws-service/example.yml
+++ b/organizations/enable-aws-service/example.yml
@@ -9,3 +9,4 @@ Resources:
     Type: Community::Organizations::EnableAWSServiceAccess
     Properties:
       ServicePrincipal: access-analyzer.amazonaws.com
+      ResourceId: enable-access-analyzer


### PR DESCRIPTION
*Issue #, if available:* #74

*Description of changes:*
Add the required `ResourceId` property to the sample CloudFormation template in the example.yml file to avoid the error `required key [ResourceId] not found`.
