### PR TITLE
Fix Community::SecurityHub::Master: "Unable to find invite from ""

### DIFF
--- a/security-hub/master/src/handlers.ts
+++ b/security-hub/master/src/handlers.ts
@@ -21,7 +21,7 @@ class Resource extends BaseResource<ResourceModel> {
     public async create(action: Action, args: HandlerArgs<ResourceModel>, service: SecurityHub, model: ResourceModel): Promise<ResourceModel> {
         const invitations = await service.listInvitations().promise();
 
-        const foundInvite = invitations.Invitations.find((invitation) => invitation.AccountId === model.masterAccountId && invitation.MemberStatus === 'INVITED');
+        const foundInvite = invitations.Invitations.find((invitation) => invitation.AccountId === model.masterAccountId && invitation.MemberStatus === 'Invited');
         if (!foundInvite) throw new exceptions.NotFound(`Unable to find invite from ${model.masterAccountId}.`, model.masterAccountId);
 
         const acceptInvitationRequest: SecurityHub.AcceptInvitationRequest = { InvitationId: foundInvite.InvitationId, MasterId: model.masterAccountId };


### PR DESCRIPTION
```
> aws securityhub list-invitations --profile XXXXX
{
    "Invitations": [
        {
            "AccountId": "XXXX",
            "InvitationId": "12345678976543357865435",
            "InvitedAt": "2023-03-10T14:53:14.874000+00:00",
            "MemberStatus": "Invited"
        }
    ]
}
```

*Issue #, if available:*

*Description of changes:*
