### PR TITLE
chore: migrate to node20

### DIFF
--- a/account/alternate-contact/.rpdk-config
+++ b/account/alternate-contact/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "Community::Account::AlternateContact",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {

--- a/account/alternate-contact/package.json
+++ b/account/alternate-contact/package.json
@@ -1,6 +1,6 @@
 {
     "name": "community-account-alternatecontact",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "description": "AWS custom resource provider named Community::Account::AlternateContact.",
     "private": true,
     "main": "dist/handlers.js",

--- a/account/alternate-contact/resource-role.yaml
+++ b/account/alternate-contact/resource-role.yaml
@@ -15,6 +15,13 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/Community-Account-AlternateContact/*
       Path: "/community-types/"
       Policies:
         - PolicyName: ResourceTypePolicy

--- a/account/alternate-contact/src/models.ts
+++ b/account/alternate-contact/src/models.ts
@@ -85,3 +85,10 @@ export class ResourceModel extends BaseModel {
     }
 }
 
+export class TypeConfigurationModel extends BaseModel {
+    ['constructor']: typeof TypeConfigurationModel;
+
+
+
+}
+

--- a/account/alternate-contact/template.yml
+++ b/account/alternate-contact/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/cloud-formation/delay/.rpdk-config
+++ b/cloud-formation/delay/.rpdk-config
@@ -1,11 +1,11 @@
 {
     "typeName": "Community::CloudFormation::Delay",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {
-        "useDocker": true,
+        "useDocker": false,
         "protocolVersion": "2.0.0"
     }
 }

--- a/cloud-formation/delay/docs/README.md
+++ b/cloud-formation/delay/docs/README.md
@@ -35,9 +35,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>4</code>
+_Minimum Length_: <code>4</code>
 
-_Maximum_: <code>15</code>
+_Maximum Length_: <code>15</code>
 
 _Pattern_: <code>^PT(?=[0-9])([0-1]?[0-9]H)?([0-9]{1,3}M)?([0-9]{1,5}S)?$</code>
 

--- a/cloud-formation/delay/package-lock.json
+++ b/cloud-formation/delay/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "community-cloudformation-delay",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cloud-formation/delay/package.json
+++ b/cloud-formation/delay/package.json
@@ -1,6 +1,6 @@
 {
     "name": "community-cloudformation-delay",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "description": "CloudFormation Resource Provider for AWS CloudFormation Delay",
     "private": true,
     "main": "dist/handlers.js",

--- a/cloud-formation/delay/template.yml
+++ b/cloud-formation/delay/template.yml
@@ -11,13 +11,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/cloud-formation/type-configuration/.rpdk-config
+++ b/cloud-formation/type-configuration/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "Community::CloudFormation::TypeConfiguration",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {

--- a/cloud-formation/type-configuration/template.yml
+++ b/cloud-formation/type-configuration/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/code-commit/approval-rule-template/.rpdk-config
+++ b/code-commit/approval-rule-template/.rpdk-config
@@ -1,11 +1,11 @@
 {
     "typeName": "Community::CodeCommit::ApprovalRuleTemplate",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {
-        "useDocker": true,
+        "useDocker": false,
         "protocolVersion": "2.0.0"
     }
 }

--- a/code-commit/approval-rule-template/docs/README.md
+++ b/code-commit/approval-rule-template/docs/README.md
@@ -39,9 +39,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>100</code>
+_Maximum Length_: <code>100</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 
@@ -53,9 +53,9 @@ _Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>1000</code>
+_Maximum Length_: <code>1000</code>
 
 _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
 

--- a/code-commit/approval-rule-template/package-lock.json
+++ b/code-commit/approval-rule-template/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "community-codecommit-approvalruletemplate",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/code-commit/approval-rule-template/package.json
+++ b/code-commit/approval-rule-template/package.json
@@ -1,6 +1,6 @@
 {
     "name": "community-codecommit-approvalruletemplate",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "description": "AWS custom resource provider named Community::CodeCommit::ApprovalRuleTemplate.",
     "private": true,
     "main": "dist/handlers.js",

--- a/code-commit/approval-rule-template/resource-role.yaml
+++ b/code-commit/approval-rule-template/resource-role.yaml
@@ -15,7 +15,14 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
-      Path: "/"
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/Community-CodeCommit-ApprovalRuleTemplate/*
+      Path: "/community-types/"
       Policies:
         - PolicyName: ResourceTypePolicy
           PolicyDocument:

--- a/code-commit/approval-rule-template/src/models.ts
+++ b/code-commit/approval-rule-template/src/models.ts
@@ -200,3 +200,10 @@ export class Statement extends BaseModel {
 
 }
 
+export class TypeConfigurationModel extends BaseModel {
+    ['constructor']: typeof TypeConfigurationModel;
+
+
+
+}
+

--- a/code-commit/approval-rule-template/template.yml
+++ b/code-commit/approval-rule-template/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/code-commit/repository-association/.rpdk-config
+++ b/code-commit/repository-association/.rpdk-config
@@ -1,11 +1,11 @@
 {
     "typeName": "Community::CodeCommit::RepositoryAssociation",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {
-        "useDocker": true,
+        "useDocker": false,
         "protocolVersion": "2.0.0"
     }
 }

--- a/code-commit/repository-association/docs/README.md
+++ b/code-commit/repository-association/docs/README.md
@@ -36,13 +36,13 @@ Properties:
 
 The Amazon Resource Name (ARN) or ID of the approval rule template for which you want to associate the repositories. It is NOT required in case ApprovalRuleTemplateName is set.
 
-_Required_: Yes
+_Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>256</code>
+_Maximum Length_: <code>256</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
@@ -50,13 +50,13 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 The name of the approval rule template for which you want to associate the repositories. It is NOT required in case ApprovalRuleTemplateArn is set.
 
-_Required_: Yes
+_Required_: No
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>100</code>
+_Maximum Length_: <code>100</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
@@ -64,7 +64,7 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 A list of repository names that will be associated with the specified approval rule template.
 
-_Required_: Yes
+_Required_: No
 
 _Type_: List of String
 

--- a/code-commit/repository-association/package-lock.json
+++ b/code-commit/repository-association/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "community-codecommit-repositoryassociation",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/code-commit/repository-association/package.json
+++ b/code-commit/repository-association/package.json
@@ -1,6 +1,6 @@
 {
     "name": "community-codecommit-repositoryassociation",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "description": "AWS custom resource provider named Community::CodeCommit::RepositoryAssociation.",
     "private": true,
     "main": "dist/handlers.js",

--- a/code-commit/repository-association/resource-role.yaml
+++ b/code-commit/repository-association/resource-role.yaml
@@ -15,7 +15,14 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
-      Path: "/"
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/Community-CodeCommit-RepositoryAssociation/*
+      Path: "/community-types/"
       Policies:
         - PolicyName: ResourceTypePolicy
           PolicyDocument:

--- a/code-commit/repository-association/src/models.ts
+++ b/code-commit/repository-association/src/models.ts
@@ -67,3 +67,10 @@ export class ResourceModel extends BaseModel {
     }
 }
 
+export class TypeConfigurationModel extends BaseModel {
+    ['constructor']: typeof TypeConfigurationModel;
+
+
+
+}
+

--- a/code-commit/repository-association/template.yml
+++ b/code-commit/repository-association/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/detective/management/.rpdk-config
+++ b/detective/management/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "Community::Detective::Management",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {

--- a/detective/management/template.yml
+++ b/detective/management/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/direct-connect/gateway/.rpdk-config
+++ b/direct-connect/gateway/.rpdk-config
@@ -2,11 +2,11 @@
     "artifact_type": "RESOURCE",
     "typeName": "Community::DirectConnect::Gateway",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {
-        "useDocker": true,
+        "useDocker": false,
         "protocolVersion": "2.0.0"
     }
 }

--- a/direct-connect/gateway/package-lock.json
+++ b/direct-connect/gateway/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "community-directconnect-gateway",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "community-directconnect-gateway",
-            "version": "0.1.0",
+            "version": "1.0.0",
             "dependencies": {
                 "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "^1.0.1",
                 "aws-resource-providers-common": "^0.5.0",

--- a/direct-connect/gateway/package.json
+++ b/direct-connect/gateway/package.json
@@ -1,6 +1,6 @@
 {
     "name": "community-directconnect-gateway",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "description": "AWS custom resource provider named Community::DirectConnect::Gateway.",
     "private": true,
     "main": "dist/handlers.js",

--- a/direct-connect/gateway/template.yml
+++ b/direct-connect/gateway/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/direct-connect/transit-virtual-interface/.rpdk-config
+++ b/direct-connect/transit-virtual-interface/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "Community::DirectConnect::TransitVirtualInterface",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {
@@ -15,7 +15,7 @@
         "endpoint_url": null,
         "region": null,
         "target_schemas": [],
-        "useDocker": true,
+        "useDocker": false,
         "protocolVersion": "2.0.0"
     }
 }

--- a/direct-connect/transit-virtual-interface/docs/README.md
+++ b/direct-connect/transit-virtual-interface/docs/README.md
@@ -90,7 +90,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### AuthKey
 
-The authentication key for BGP configuration. This string has a minimum length of 6 characters and and a maximun lenth of 80 characters.
+The authentication key for BGP configuration. This string has a minimum length of 6 characters and and a maximum length of 80 characters.
 
 _Required_: No
 

--- a/direct-connect/transit-virtual-interface/package-lock.json
+++ b/direct-connect/transit-virtual-interface/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "community-directconnect-transitvirtualinterface",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "community-directconnect-transitvirtualinterface",
-            "version": "0.1.0",
+            "version": "1.0.0",
             "dependencies": {
                 "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "^1.0.1",
                 "aws-resource-providers-common": "^0.5.0",

--- a/direct-connect/transit-virtual-interface/package.json
+++ b/direct-connect/transit-virtual-interface/package.json
@@ -1,6 +1,6 @@
 {
     "name": "community-directconnect-transitvirtualinterface",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "description": "AWS custom resource provider named Community::DirectConnect::TransitVirtualInterface.",
     "private": true,
     "main": "dist/handlers.js",

--- a/direct-connect/transit-virtual-interface/template.yml
+++ b/direct-connect/transit-virtual-interface/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/ec2/core-network-route/.rpdk-config
+++ b/ec2/core-network-route/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "Community::EC2::CoreNetworkRoute",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {
@@ -15,7 +15,7 @@
         "endpoint_url": null,
         "region": null,
         "target_schemas": [],
-        "useDocker": true,
+        "useDocker": false,
         "protocolVersion": "2.0.0"
     }
 }

--- a/ec2/core-network-route/package-lock.json
+++ b/ec2/core-network-route/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "community-ec2-corenetworkroute",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "community-ec2-corenetworkroute",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "dependencies": {
                 "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "^1.0.3",
                 "aws-resource-providers-common": "^0.5.0",

--- a/ec2/core-network-route/package.json
+++ b/ec2/core-network-route/package.json
@@ -1,6 +1,6 @@
 {
     "name": "community-ec2-corenetworkroute",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "AWS custom resource provider named Community::EC2::CoreNetworkRoute.",
     "private": true,
     "main": "dist/handlers.js",

--- a/ec2/core-network-route/template.yml
+++ b/ec2/core-network-route/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/ec2/ebs-encryption-defaults/.rpdk-config
+++ b/ec2/ebs-encryption-defaults/.rpdk-config
@@ -1,11 +1,11 @@
 {
     "typeName": "Community::Organizations::EbsEncryptionDefaults",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {
-        "useDocker": true,
+        "useDocker": false,
         "protocolVersion": "2.0.0"
     }
 }

--- a/ec2/ebs-encryption-defaults/package.json
+++ b/ec2/ebs-encryption-defaults/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "community-ec2-ebsencryptiondefaults",
-    "version": "0.2.2",
+    "name": "community-organizations-ebsencryptiondefaults",
+    "version": "1.0.0",
     "description": "AWS custom resource provider named Community::Organizations::EbsEncryptionDefaults.",
     "private": true,
     "main": "dist/handlers.js",

--- a/ec2/ebs-encryption-defaults/resource-role.yaml
+++ b/ec2/ebs-encryption-defaults/resource-role.yaml
@@ -15,6 +15,13 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/Community-Organizations-EbsEncryptionDefaults/*
       Path: "/community-types/"
       Policies:
         - PolicyName: ResourceTypePolicy

--- a/ec2/ebs-encryption-defaults/src/models.ts
+++ b/ec2/ebs-encryption-defaults/src/models.ts
@@ -58,3 +58,10 @@ export class ResourceModel extends BaseModel {
     }
 }
 
+export class TypeConfigurationModel extends BaseModel {
+    ['constructor']: typeof TypeConfigurationModel;
+
+
+
+}
+

--- a/ec2/ebs-encryption-defaults/template.yml
+++ b/ec2/ebs-encryption-defaults/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/ec2/no-default-vpc/.rpdk-config
+++ b/ec2/no-default-vpc/.rpdk-config
@@ -1,11 +1,11 @@
 {
     "typeName": "Community::Organizations::NoDefaultVPC",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {
-        "useDocker": true,
+        "useDocker": false,
         "protocolVersion": "2.0.0"
     }
 }

--- a/ec2/no-default-vpc/package.json
+++ b/ec2/no-default-vpc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "community-organizations-nodefaultvpc",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "description": "AWS custom resource provider named Community::Organizations::NoDefaultVPC.",
     "main": "dist/handlers.js",
     "files": [

--- a/ec2/no-default-vpc/resource-role.yaml
+++ b/ec2/no-default-vpc/resource-role.yaml
@@ -15,7 +15,14 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
-      Path: "/"
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/Community-Organizations-NoDefaultVPC/*
+      Path: "/community-types/"
       Policies:
         - PolicyName: ResourceTypePolicy
           PolicyDocument:

--- a/ec2/no-default-vpc/src/models.ts
+++ b/ec2/no-default-vpc/src/models.ts
@@ -40,3 +40,10 @@ export class ResourceModel extends BaseModel {
     }
 }
 
+export class TypeConfigurationModel extends BaseModel {
+    ['constructor']: typeof TypeConfigurationModel;
+
+
+
+}
+

--- a/ec2/no-default-vpc/template.yml
+++ b/ec2/no-default-vpc/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/iam/oidc-providers/.rpdk-config
+++ b/iam/oidc-providers/.rpdk-config
@@ -1,7 +1,7 @@
 {
     "typeName": "Community::IAM::OpenIDConnectProvider",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {

--- a/iam/oidc-providers/template.yml
+++ b/iam/oidc-providers/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/iam/password-policy/.rpdk-config
+++ b/iam/password-policy/.rpdk-config
@@ -1,11 +1,11 @@
 {
     "typeName": "Community::IAM::PasswordPolicy",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {
-        "useDocker": true,
+        "useDocker": false,
         "protocolVersion": "2.0.0"
     }
 }

--- a/iam/password-policy/template.yml
+++ b/iam/password-policy/template.yml
@@ -11,12 +11,12 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TestEntrypoint:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./

--- a/iam/saml-provider/.rpdk-config
+++ b/iam/saml-provider/.rpdk-config
@@ -1,7 +1,7 @@
 {
     "typeName": "Community::IAM::SamlProvider",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {

--- a/iam/saml-provider/template.yml
+++ b/iam/saml-provider/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/organizations/delegated-admin/.rpdk-config
+++ b/organizations/delegated-admin/.rpdk-config
@@ -1,7 +1,7 @@
 {
     "typeName": "Community::Organizations::DelegatedAdmin",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {

--- a/organizations/delegated-admin/template.yml
+++ b/organizations/delegated-admin/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/organizations/enable-aws-service/.rpdk-config
+++ b/organizations/enable-aws-service/.rpdk-config
@@ -1,7 +1,7 @@
 {
     "typeName": "Community::Organizations::EnableAWSServiceAccess",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {
@@ -10,7 +10,7 @@
         "verbose": 0,
         "force": false,
         "type_name": null,
-        "useDocker": true,
+        "useDocker": false,
         "protocolVersion": "2.0.0"
     }
 }

--- a/organizations/enable-aws-service/docs/README.md
+++ b/organizations/enable-aws-service/docs/README.md
@@ -45,7 +45,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 Primary Identifier for this resource
 
-_Required_: Yes
+_Required_: No
 
 _Type_: String
 

--- a/organizations/enable-aws-service/package-lock.json
+++ b/organizations/enable-aws-service/package-lock.json
@@ -1,16 +1,15 @@
 {
     "name": "community-organizations-enableawsserviceaccess",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "community-organizations-enableawsserviceaccess",
-            "version": "0.1.0",
+            "version": "1.0.0",
             "dependencies": {
-                "aws-resource-providers-common": "^0.2.0",
-                "aws-sdk": "^2.656.0",
-                "cfn-rpdk": "npm:@org-formation/cfn-rpdk@^0.4.0",
+                "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "^1.0.1",
+                "aws-resource-providers-common": "^0.5.0",
                 "class-transformer": "^0.3.1",
                 "uuid": "^7.0.3"
             },
@@ -21,6 +20,31 @@
             },
             "optionalDependencies": {
                 "aws-sdk": "^2.656.0"
+            }
+        },
+        "node_modules/@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib/-/cloudformation-cli-typescript-lib-1.0.5.tgz",
+            "integrity": "sha512-O4VM2E9R4qTqMXW1BWsVWq+uQkm8x7xX9XhFUK/UBzj9ILd11y9afdrYKiubcYJAE7wNG7tGfyOf4vic2+BM8w==",
+            "dependencies": {
+                "@org-formation/tombok": "^0.0.1",
+                "autobind-decorator": "^2.4.0",
+                "class-transformer": "^0.3.1",
+                "reflect-metadata": "^0.1.13",
+                "string.prototype.replaceall": "^1.0.3",
+                "uuid": "^7.0.2"
+            },
+            "engines": {
+                "node": ">=14.0.0",
+                "npm": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "aws-sdk": "^2.712.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-sdk": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@org-formation/tombok": {
@@ -53,45 +77,62 @@
                 "npm": ">=6.4.1"
             }
         },
-        "node_modules/aws-resource-providers-common": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/aws-resource-providers-common/-/aws-resource-providers-common-0.2.3.tgz",
-            "integrity": "sha512-DVLaqozhBnbrhUX5/OCtiuuHnrB21673bG9UKP33Gmb+2t15sAFQzRnl/IzyrU2kbl5gEW8L+4Jm7PYx+GRByw==",
-            "dependencies": {
-                "aws-sdk": "^2.656.0",
-                "cfn-rpdk": "npm:@org-formation/cfn-rpdk@0.x"
+        "node_modules/available-typed-arrays": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+            "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+            "optional": true,
+            "engines": {
+                "node": ">= 0.4"
             },
-            "optionalDependencies": {
-                "aws-sdk": "^2.656.0"
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/aws-resource-providers-common": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/aws-resource-providers-common/-/aws-resource-providers-common-0.5.0.tgz",
+            "integrity": "sha512-mqIQRDEcIRXtiKbqcrSRLZEcZ2GmBFyEpByK+8aVQ5Ds1/oTe1HSuRd04ZeaAgG6z96w1lNHfxXexQjeGt7MCg==",
+            "dependencies": {
+                "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "^1.0.1"
+            },
+            "peerDependencies": {
+                "aws-sdk": "^2.1058.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-sdk": {
+                    "optional": true
+                }
             }
         },
         "node_modules/aws-sdk": {
-            "version": "2.789.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.789.0.tgz",
-            "integrity": "sha512-Jqq+M4N0EgkyS4OPf05UHa7IWUcpuBdnpwMRgBnu4Ju6PxpOTh1UQcmYepVmIN3m6YVpLwFctEYzAMJFM3LT1A==",
+            "version": "2.1541.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1541.0.tgz",
+            "integrity": "sha512-+xS/Gq/+j/RKb3A6SHXn6tOCaog1O3troklpVxxNaqVNnq+zlwjFderGNzR6S4ftfNG7sKMUP++Znsqte8GMaw==",
             "optional": true,
             "dependencies": {
                 "buffer": "4.9.2",
                 "events": "1.1.1",
                 "ieee754": "1.1.13",
-                "jmespath": "0.15.0",
+                "jmespath": "0.16.0",
                 "querystring": "0.2.0",
                 "sax": "1.2.1",
                 "url": "0.10.3",
-                "uuid": "3.3.2",
-                "xml2js": "0.4.19"
+                "util": "^0.12.4",
+                "uuid": "8.0.0",
+                "xml2js": "0.5.0"
             },
             "engines": {
-                "node": ">= 0.8.0"
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/aws-sdk/node_modules/uuid": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+            "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
             "optional": true,
             "bin": {
-                "uuid": "bin/uuid"
+                "uuid": "dist/bin/uuid"
             }
         },
         "node_modules/base64-js": {
@@ -126,72 +167,35 @@
             }
         },
         "node_modules/call-bind": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
-            "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+            "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.0"
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.1",
+                "set-function-length": "^1.1.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/cfn-rpdk": {
-            "name": "@org-formation/cfn-rpdk",
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@org-formation/cfn-rpdk/-/cfn-rpdk-0.4.0.tgz",
-            "integrity": "sha512-3JSVoN3OxQrVD68O9H6yUhawUQg7nAITqRydTfs517qALgS5foD4qmZDV9NB3SCBF5XgU0pEwDTY3tqwit1exQ==",
-            "dependencies": {
-                "@org-formation/tombok": "^0.0.1",
-                "autobind-decorator": "^2.4.0",
-                "aws-sdk": "~2.712.0",
-                "class-transformer": "^0.3.1",
-                "reflect-metadata": "^0.1.13",
-                "string.prototype.replaceall": "^1.0.3",
-                "uuid": "^7.0.2"
-            },
-            "engines": {
-                "node": ">=10.4.0",
-                "npm": ">=5.6.0"
-            },
-            "optionalDependencies": {
-                "aws-sdk": "~2.712.0"
-            }
-        },
-        "node_modules/cfn-rpdk/node_modules/aws-sdk": {
-            "version": "2.712.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.712.0.tgz",
-            "integrity": "sha512-C3SLWanFydoWJwtKNi73BG9uB6UzrUuECaAiplOEVBltO/R4sBsHWhwTBuxS02eTNdRrgulu19bJ5RWt+OuXiA==",
-            "optional": true,
-            "dependencies": {
-                "buffer": "4.9.2",
-                "events": "1.1.1",
-                "ieee754": "1.1.13",
-                "jmespath": "0.15.0",
-                "querystring": "0.2.0",
-                "sax": "1.2.1",
-                "url": "0.10.3",
-                "uuid": "3.3.2",
-                "xml2js": "0.4.19"
-            },
-            "engines": {
-                "node": ">= 0.8.0"
-            }
-        },
-        "node_modules/cfn-rpdk/node_modules/aws-sdk/node_modules/uuid": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-            "optional": true,
-            "bin": {
-                "uuid": "bin/uuid"
             }
         },
         "node_modules/class-transformer": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.3.1.tgz",
             "integrity": "sha512-cKFwohpJbuMovS8xVLmn8N2AUbAuc8pVo4zEfsUVo8qgECOogns1WVk/FkOZoxhOPTyTYFckuoH+13FO+MQ8GA=="
+        },
+        "node_modules/define-data-property": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+            "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+            "dependencies": {
+                "get-intrinsic": "^1.2.1",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/define-properties": {
             "version": "1.1.3",
@@ -253,19 +257,43 @@
                 "node": ">=0.4.x"
             }
         },
+        "node_modules/for-each": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+            "optional": true,
+            "dependencies": {
+                "is-callable": "^1.1.3"
+            }
+        },
         "node_modules/function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
-            "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+            "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.1"
+                "function-bind": "^1.1.2",
+                "has-proto": "^1.0.1",
+                "has-symbols": "^1.0.3",
+                "hasown": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/gopd": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+            "dependencies": {
+                "get-intrinsic": "^1.1.3"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -282,10 +310,21 @@
                 "node": ">= 0.4.0"
             }
         },
-        "node_modules/has-symbols": {
+        "node_modules/has-property-descriptors": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+            "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+            "dependencies": {
+                "get-intrinsic": "^1.2.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+            "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
             "engines": {
                 "node": ">= 0.4"
             },
@@ -293,11 +332,70 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/has-symbols": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "optional": true,
+            "dependencies": {
+                "has-symbols": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+            "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/ieee754": {
             "version": "1.1.13",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
             "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
             "optional": true
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "optional": true
+        },
+        "node_modules/is-arguments": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+            "optional": true,
+            "dependencies": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/is-callable": {
             "version": "1.2.2",
@@ -314,6 +412,21 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
             "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-generator-function": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+            "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+            "optional": true,
+            "dependencies": {
+                "has-tostringtag": "^1.0.0"
+            },
             "engines": {
                 "node": ">= 0.4"
             },
@@ -357,6 +470,21 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/is-typed-array": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+            "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+            "optional": true,
+            "dependencies": {
+                "which-typed-array": "^1.1.11"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -364,9 +492,9 @@
             "optional": true
         },
         "node_modules/jmespath": {
-            "version": "0.15.0",
-            "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-            "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+            "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
             "optional": true,
             "engines": {
                 "node": ">= 0.6.0"
@@ -428,8 +556,23 @@
         "node_modules/sax": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+            "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
             "optional": true
+        },
+        "node_modules/set-function-length": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
+            "integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
+            "dependencies": {
+                "define-data-property": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.2",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/string.prototype.replaceall": {
             "version": "1.0.3",
@@ -543,6 +686,19 @@
                 "querystring": "0.2.0"
             }
         },
+        "node_modules/util": {
+            "version": "0.12.5",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+            "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+            "optional": true,
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "is-arguments": "^1.0.4",
+                "is-generator-function": "^1.0.7",
+                "is-typed-array": "^1.1.3",
+                "which-typed-array": "^1.1.2"
+            }
+        },
         "node_modules/uuid": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
@@ -551,20 +707,42 @@
                 "uuid": "dist/bin/uuid"
             }
         },
+        "node_modules/which-typed-array": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
+            "integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
+            "optional": true,
+            "dependencies": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.4",
+                "for-each": "^0.3.3",
+                "gopd": "^1.0.1",
+                "has-tostringtag": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/xml2js": {
-            "version": "0.4.19",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+            "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
             "optional": true,
             "dependencies": {
                 "sax": ">=0.6.0",
-                "xmlbuilder": "~9.0.1"
+                "xmlbuilder": "~11.0.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
             }
         },
         "node_modules/xmlbuilder": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
             "optional": true,
             "engines": {
                 "node": ">=4.0"
@@ -572,6 +750,19 @@
         }
     },
     "dependencies": {
+        "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib/-/cloudformation-cli-typescript-lib-1.0.5.tgz",
+            "integrity": "sha512-O4VM2E9R4qTqMXW1BWsVWq+uQkm8x7xX9XhFUK/UBzj9ILd11y9afdrYKiubcYJAE7wNG7tGfyOf4vic2+BM8w==",
+            "requires": {
+                "@org-formation/tombok": "^0.0.1",
+                "autobind-decorator": "^2.4.0",
+                "class-transformer": "^0.3.1",
+                "reflect-metadata": "^0.1.13",
+                "string.prototype.replaceall": "^1.0.3",
+                "uuid": "^7.0.2"
+            }
+        },
         "@org-formation/tombok": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/@org-formation/tombok/-/tombok-0.0.1.tgz",
@@ -594,36 +785,42 @@
             "resolved": "https://registry.npmjs.org/autobind-decorator/-/autobind-decorator-2.4.0.tgz",
             "integrity": "sha512-OGYhWUO72V6DafbF8PM8rm3EPbfuyMZcJhtm5/n26IDwO18pohE4eNazLoCGhPiXOCD0gEGmrbU3849QvM8bbw=="
         },
+        "available-typed-arrays": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+            "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+            "optional": true
+        },
         "aws-resource-providers-common": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/aws-resource-providers-common/-/aws-resource-providers-common-0.2.3.tgz",
-            "integrity": "sha512-DVLaqozhBnbrhUX5/OCtiuuHnrB21673bG9UKP33Gmb+2t15sAFQzRnl/IzyrU2kbl5gEW8L+4Jm7PYx+GRByw==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/aws-resource-providers-common/-/aws-resource-providers-common-0.5.0.tgz",
+            "integrity": "sha512-mqIQRDEcIRXtiKbqcrSRLZEcZ2GmBFyEpByK+8aVQ5Ds1/oTe1HSuRd04ZeaAgG6z96w1lNHfxXexQjeGt7MCg==",
             "requires": {
-                "aws-sdk": "^2.656.0",
-                "cfn-rpdk": "npm:@org-formation/cfn-rpdk@0.x"
+                "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "^1.0.1"
             }
         },
         "aws-sdk": {
-            "version": "2.789.0",
-            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.789.0.tgz",
-            "integrity": "sha512-Jqq+M4N0EgkyS4OPf05UHa7IWUcpuBdnpwMRgBnu4Ju6PxpOTh1UQcmYepVmIN3m6YVpLwFctEYzAMJFM3LT1A==",
+            "version": "2.1541.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1541.0.tgz",
+            "integrity": "sha512-+xS/Gq/+j/RKb3A6SHXn6tOCaog1O3troklpVxxNaqVNnq+zlwjFderGNzR6S4ftfNG7sKMUP++Znsqte8GMaw==",
             "optional": true,
             "requires": {
                 "buffer": "4.9.2",
                 "events": "1.1.1",
                 "ieee754": "1.1.13",
-                "jmespath": "0.15.0",
+                "jmespath": "0.16.0",
                 "querystring": "0.2.0",
                 "sax": "1.2.1",
                 "url": "0.10.3",
-                "uuid": "3.3.2",
-                "xml2js": "0.4.19"
+                "util": "^0.12.4",
+                "uuid": "8.0.0",
+                "xml2js": "0.5.0"
             },
             "dependencies": {
                 "uuid": {
-                    "version": "3.3.2",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-                    "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+                    "version": "8.0.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+                    "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
                     "optional": true
                 }
             }
@@ -646,59 +843,29 @@
             }
         },
         "call-bind": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
-            "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+            "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
             "requires": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.0"
-            }
-        },
-        "cfn-rpdk": {
-            "version": "npm:@org-formation/cfn-rpdk@0.4.0",
-            "resolved": "https://registry.npmjs.org/@org-formation/cfn-rpdk/-/cfn-rpdk-0.4.0.tgz",
-            "integrity": "sha512-3JSVoN3OxQrVD68O9H6yUhawUQg7nAITqRydTfs517qALgS5foD4qmZDV9NB3SCBF5XgU0pEwDTY3tqwit1exQ==",
-            "requires": {
-                "@org-formation/tombok": "^0.0.1",
-                "autobind-decorator": "^2.4.0",
-                "aws-sdk": "~2.712.0",
-                "class-transformer": "^0.3.1",
-                "reflect-metadata": "^0.1.13",
-                "string.prototype.replaceall": "^1.0.3",
-                "uuid": "^7.0.2"
-            },
-            "dependencies": {
-                "aws-sdk": {
-                    "version": "2.712.0",
-                    "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.712.0.tgz",
-                    "integrity": "sha512-C3SLWanFydoWJwtKNi73BG9uB6UzrUuECaAiplOEVBltO/R4sBsHWhwTBuxS02eTNdRrgulu19bJ5RWt+OuXiA==",
-                    "optional": true,
-                    "requires": {
-                        "buffer": "4.9.2",
-                        "events": "1.1.1",
-                        "ieee754": "1.1.13",
-                        "jmespath": "0.15.0",
-                        "querystring": "0.2.0",
-                        "sax": "1.2.1",
-                        "url": "0.10.3",
-                        "uuid": "3.3.2",
-                        "xml2js": "0.4.19"
-                    },
-                    "dependencies": {
-                        "uuid": {
-                            "version": "3.3.2",
-                            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-                            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-                            "optional": true
-                        }
-                    }
-                }
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.1",
+                "set-function-length": "^1.1.1"
             }
         },
         "class-transformer": {
             "version": "0.3.1",
             "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.3.1.tgz",
             "integrity": "sha512-cKFwohpJbuMovS8xVLmn8N2AUbAuc8pVo4zEfsUVo8qgECOogns1WVk/FkOZoxhOPTyTYFckuoH+13FO+MQ8GA=="
+        },
+        "define-data-property": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+            "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+            "requires": {
+                "get-intrinsic": "^1.2.1",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.0"
+            }
         },
         "define-properties": {
             "version": "1.1.3",
@@ -742,19 +909,37 @@
             "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
             "optional": true
         },
+        "for-each": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+            "optional": true,
+            "requires": {
+                "is-callable": "^1.1.3"
+            }
+        },
         "function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
         },
         "get-intrinsic": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
-            "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+            "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
             "requires": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
-                "has-symbols": "^1.0.1"
+                "function-bind": "^1.1.2",
+                "has-proto": "^1.0.1",
+                "has-symbols": "^1.0.3",
+                "hasown": "^2.0.0"
+            }
+        },
+        "gopd": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+            "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+            "requires": {
+                "get-intrinsic": "^1.1.3"
             }
         },
         "has": {
@@ -765,16 +950,62 @@
                 "function-bind": "^1.1.1"
             }
         },
-        "has-symbols": {
+        "has-property-descriptors": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+            "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+            "requires": {
+                "get-intrinsic": "^1.2.2"
+            }
+        },
+        "has-proto": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+            "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
+        },
+        "has-symbols": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+        },
+        "has-tostringtag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "optional": true,
+            "requires": {
+                "has-symbols": "^1.0.2"
+            }
+        },
+        "hasown": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+            "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+            "requires": {
+                "function-bind": "^1.1.2"
+            }
         },
         "ieee754": {
             "version": "1.1.13",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
             "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
             "optional": true
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "optional": true
+        },
+        "is-arguments": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+            "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+            "optional": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
+            }
         },
         "is-callable": {
             "version": "1.2.2",
@@ -785,6 +1016,15 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
             "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+        },
+        "is-generator-function": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+            "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+            "optional": true,
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
         },
         "is-negative-zero": {
             "version": "2.0.0",
@@ -807,6 +1047,15 @@
                 "has-symbols": "^1.0.1"
             }
         },
+        "is-typed-array": {
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
+            "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
+            "optional": true,
+            "requires": {
+                "which-typed-array": "^1.1.11"
+            }
+        },
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -814,9 +1063,9 @@
             "optional": true
         },
         "jmespath": {
-            "version": "0.15.0",
-            "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-            "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+            "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
             "optional": true
         },
         "object-inspect": {
@@ -860,8 +1109,20 @@
         "sax": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+            "integrity": "sha512-8I2a3LovHTOpm7NV5yOyO8IHqgVsfK4+UuySrXU8YXkSRX7k6hCV9b3HrkKCr3nMpgj+0bmocaJJWpvp1oc7ZA==",
             "optional": true
+        },
+        "set-function-length": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
+            "integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
+            "requires": {
+                "define-data-property": "^1.1.1",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.2",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.1"
+            }
         },
         "string.prototype.replaceall": {
             "version": "1.0.3",
@@ -951,25 +1212,51 @@
                 "querystring": "0.2.0"
             }
         },
+        "util": {
+            "version": "0.12.5",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+            "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+            "optional": true,
+            "requires": {
+                "inherits": "^2.0.3",
+                "is-arguments": "^1.0.4",
+                "is-generator-function": "^1.0.7",
+                "is-typed-array": "^1.1.3",
+                "which-typed-array": "^1.1.2"
+            }
+        },
         "uuid": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
             "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="
         },
+        "which-typed-array": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
+            "integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
+            "optional": true,
+            "requires": {
+                "available-typed-arrays": "^1.0.5",
+                "call-bind": "^1.0.4",
+                "for-each": "^0.3.3",
+                "gopd": "^1.0.1",
+                "has-tostringtag": "^1.0.0"
+            }
+        },
         "xml2js": {
-            "version": "0.4.19",
-            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+            "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
             "optional": true,
             "requires": {
                 "sax": ">=0.6.0",
-                "xmlbuilder": "~9.0.1"
+                "xmlbuilder": "~11.0.0"
             }
         },
         "xmlbuilder": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
             "optional": true
         }
     }

--- a/organizations/enable-aws-service/package.json
+++ b/organizations/enable-aws-service/package.json
@@ -1,6 +1,6 @@
 {
     "name": "community-organizations-enableawsserviceaccess",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "description": "AWS custom resource provider named Community::Organizations::EnableAWSService.",
     "private": true,
     "main": "dist/handlers.js",
@@ -20,9 +20,9 @@
         "validate": "cfn validate"
     },
     "dependencies": {
-        "aws-resource-providers-common": "^0.2.0",
+        "aws-resource-providers-common": "^0.5.0",
         "aws-sdk": "^2.656.0",
-        "cfn-rpdk": "npm:@org-formation/cfn-rpdk@^0.4.0",
+        "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "^1.0.1",
         "class-transformer": "^0.3.1",
         "uuid": "^7.0.3"
     },

--- a/organizations/enable-aws-service/resource-role.yaml
+++ b/organizations/enable-aws-service/resource-role.yaml
@@ -15,6 +15,13 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/Community-Organizations-EnableAWSServiceAccess/*
       Path: "/"
       Policies:
         - PolicyName: ResourceTypePolicy

--- a/organizations/enable-aws-service/src/handlers.ts
+++ b/organizations/enable-aws-service/src/handlers.ts
@@ -2,7 +2,7 @@ import { Organizations } from 'aws-sdk';
 import { commonAws, HandlerArgs } from 'aws-resource-providers-common';
 // import { v4 as uuidv4 } from 'uuid';
 import { v4 as uuidv4 } from 'uuid';
-import { Action, BaseResource, exceptions, handlerEvent } from 'cfn-rpdk';
+import { Action, BaseResource, exceptions, handlerEvent } from '@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib';
 import { ResourceModel } from './models';
 import { DisableAWSServiceAccessRequest, EnableAWSServiceAccessRequest } from 'aws-sdk/clients/organizations';
 
@@ -85,14 +85,6 @@ class Resource extends BaseResource<ResourceModel> {
     public async delete(action: Action, args: HandlerArgs<ResourceModel>, service: Organizations): Promise<null> {
         const { desiredResourceState, logicalResourceIdentifier, previousResourceState } = args.request;
 
-        // let model = args.request.
-        
-        //const request1 : DeregisterDelegatedAdministratorRequest = {
-        //    AccountId : previousResourceState.accountNumber,
-        //    ServicePrincipal : previousResourceState.servicePrincipal
-        //}
-
-        //await service.deregisterDelegatedAdministrator(request1).promise();
 
         const request2 : DisableAWSServiceAccessRequest = {
             ServicePrincipal : desiredResourceState.servicePrincipal

--- a/organizations/enable-aws-service/src/models.ts
+++ b/organizations/enable-aws-service/src/models.ts
@@ -1,5 +1,5 @@
 // This is a generated file. Modifications will be overwritten.
-import { BaseModel, Dict, integer, Integer, Optional, transformValue } from 'cfn-rpdk';
+import { BaseModel, Dict, integer, Integer, Optional, transformValue } from '@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib';
 import { Exclude, Expose, Type, Transform } from 'class-transformer';
 
 export class ResourceModel extends BaseModel {
@@ -47,5 +47,12 @@ export class ResourceModel extends BaseModel {
         // only return the identifiers if any can be used
         return identifiers.length === 0 ? null : identifiers;
     }
+}
+
+export class TypeConfigurationModel extends BaseModel {
+    ['constructor']: typeof TypeConfigurationModel;
+
+
+
 }
 

--- a/organizations/enable-aws-service/template.yml
+++ b/organizations/enable-aws-service/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/organizations/policy/.rpdk-config
+++ b/organizations/policy/.rpdk-config
@@ -1,7 +1,7 @@
 {
     "typeName": "Community::Organizations::Policy",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {

--- a/organizations/policy/template.yml
+++ b/organizations/policy/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/route53/vpc-association-authorization/.rpdk-config
+++ b/route53/vpc-association-authorization/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "Community::Route53::VPCAssociationAuthorization",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {
@@ -15,7 +15,7 @@
         "endpoint_url": null,
         "region": null,
         "target_schemas": [],
-        "useDocker": true,
+        "useDocker": false,
         "protocolVersion": "2.0.0"
     }
 }

--- a/route53/vpc-association-authorization/package-lock.json
+++ b/route53/vpc-association-authorization/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "community-route53-vpcassociationauthorization",
-    "version": "0.2.0",
+    "version": "1.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "community-route53-vpcassociationauthorization",
-            "version": "0.2.0",
+            "version": "1.0.0",
             "dependencies": {
                 "@amazon-web-services-cloudformation/cloudformation-cli-typescript-lib": "^1.0.3",
                 "aws-resource-providers-common": "^0.5.0",

--- a/route53/vpc-association-authorization/package.json
+++ b/route53/vpc-association-authorization/package.json
@@ -1,6 +1,6 @@
 {
     "name": "community-route53-vpcassociationauthorization",
-    "version": "0.2.0",
+    "version": "1.0.0",
     "description": "AWS custom resource provider named Community::Route53::VPCAssociationAuthorization.",
     "private": true,
     "main": "dist/handlers.js",

--- a/route53/vpc-association-authorization/resource-role.yaml
+++ b/route53/vpc-association-authorization/resource-role.yaml
@@ -22,7 +22,7 @@ Resources:
               StringLike:
                 aws:SourceArn:
                   Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/Community-Route53-VPCAssociationAuthorization/*
-      Path: "/"
+      Path: "/community-types/"
       Policies:
         - PolicyName: ResourceTypePolicy
           PolicyDocument:

--- a/route53/vpc-association-authorization/template.yml
+++ b/route53/vpc-association-authorization/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/route53/vpc-association/.rpdk-config
+++ b/route53/vpc-association/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "Community::Route53::VPCAssociation",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {

--- a/route53/vpc-association/template.yml
+++ b/route53/vpc-association/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/s3/public-access-block/.rpdk-config
+++ b/s3/public-access-block/.rpdk-config
@@ -1,11 +1,11 @@
 {
     "typeName": "Community::S3::PublicAccessBlock",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {
-        "useDocker": true,
+        "useDocker": false,
         "protocolVersion": "2.0.0"
     }
 }

--- a/s3/public-access-block/package.json
+++ b/s3/public-access-block/package.json
@@ -1,6 +1,6 @@
 {
     "name": "community-s3-publicaccessblock",
-    "version": "0.2.2",
+    "version": "1.0.0",
     "description": "AWS custom resource provider named Community::S3::PublicAccessBlock.",
     "private": true,
     "main": "dist/handlers.js",

--- a/s3/public-access-block/resource-role.yaml
+++ b/s3/public-access-block/resource-role.yaml
@@ -15,6 +15,13 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/Community-S3-PublicAccessBlock/*
       Path: "/community-types/"
       Policies:
         - PolicyName: ResourceTypePolicy

--- a/s3/public-access-block/src/models.ts
+++ b/s3/public-access-block/src/models.ts
@@ -76,3 +76,10 @@ export class ResourceModel extends BaseModel {
     }
 }
 
+export class TypeConfigurationModel extends BaseModel {
+    ['constructor']: typeof TypeConfigurationModel;
+
+
+
+}
+

--- a/s3/public-access-block/template.yml
+++ b/s3/public-access-block/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/security-hub/action-target/.rpdk-config
+++ b/security-hub/action-target/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "Community::SecurityHub::ActionTarget",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {
@@ -12,7 +12,7 @@
         "force": false,
         "type_name": null,
         "artifact_type": null,
-        "useDocker": true,
+        "useDocker": false,
         "protocolVersion": "2.0.0"
     }
 }

--- a/security-hub/action-target/docs/README.md
+++ b/security-hub/action-target/docs/README.md
@@ -39,9 +39,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>20</code>
+_Maximum Length_: <code>20</code>
 
 _Pattern_: <code>.*\S.*</code>
 
@@ -55,9 +55,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>100</code>
+_Maximum Length_: <code>100</code>
 
 _Pattern_: <code>.*\S.*</code>
 
@@ -71,9 +71,9 @@ _Required_: Yes
 
 _Type_: String
 
-_Minimum_: <code>1</code>
+_Minimum Length_: <code>1</code>
 
-_Maximum_: <code>1000</code>
+_Maximum Length_: <code>1000</code>
 
 _Pattern_: <code>.*\S.*</code>
 

--- a/security-hub/action-target/package-lock.json
+++ b/security-hub/action-target/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "community-securityhub-actiontarget",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/security-hub/action-target/package.json
+++ b/security-hub/action-target/package.json
@@ -1,6 +1,6 @@
 {
     "name": "community-securityhub-actiontarget",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "description": "AWS custom resource provider named Community::SecurityHub::ActionTarget.",
     "private": true,
     "main": "dist/handlers.js",

--- a/security-hub/action-target/resource-role.yaml
+++ b/security-hub/action-target/resource-role.yaml
@@ -15,6 +15,13 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/Community-SecurityHub-ActionTarget/*
       Path: "/"
       Policies:
         - PolicyName: ResourceTypePolicy

--- a/security-hub/action-target/src/models.ts
+++ b/security-hub/action-target/src/models.ts
@@ -67,3 +67,10 @@ export class ResourceModel extends BaseModel {
     }
 }
 
+export class TypeConfigurationModel extends BaseModel {
+    ['constructor']: typeof TypeConfigurationModel;
+
+
+
+}
+

--- a/security-hub/action-target/template.yml
+++ b/security-hub/action-target/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/security-hub/finding-aggregation/.rpdk-config
+++ b/security-hub/finding-aggregation/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "Community::SecurityHub::FindingAggregation",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {

--- a/security-hub/finding-aggregation/template.yml
+++ b/security-hub/finding-aggregation/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/security-hub/hub/.rpdk-config
+++ b/security-hub/hub/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "Community::SecurityHub::Hub",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {

--- a/security-hub/hub/template.yml
+++ b/security-hub/hub/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/security-hub/insight/.rpdk-config
+++ b/security-hub/insight/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "Community::SecurityHub::Insight",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {

--- a/security-hub/insight/template.yml
+++ b/security-hub/insight/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/security-hub/master/.rpdk-config
+++ b/security-hub/master/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "Community::SecurityHub::Master",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {

--- a/security-hub/master/template.yml
+++ b/security-hub/master/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/security-hub/members/.rpdk-config
+++ b/security-hub/members/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "Community::SecurityHub::Members",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {

--- a/security-hub/members/template.yml
+++ b/security-hub/members/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/security-hub/security-control/.rpdk-config
+++ b/security-hub/security-control/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "Community::SecurityHub::SecurityControl",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {

--- a/security-hub/security-control/template.yml
+++ b/security-hub/security-control/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/security-hub/standards-control/.rpdk-config
+++ b/security-hub/standards-control/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "Community::SecurityHub::StandardsControl",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {

--- a/security-hub/standards-control/template.yml
+++ b/security-hub/standards-control/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/security-hub/standards/.rpdk-config
+++ b/security-hub/standards/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "Community::SecurityHub::Standards",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {

--- a/security-hub/standards/template.yml
+++ b/security-hub/standards/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/service-quotas/cloud-formation/.rpdk-config
+++ b/service-quotas/cloud-formation/.rpdk-config
@@ -1,11 +1,11 @@
 {
     "typeName": "Community::ServiceQuotas::CloudFormation",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {
-        "useDocker": true,
+        "useDocker": false,
         "protocolVersion": "2.0.0"
     }
 }

--- a/service-quotas/cloud-formation/package-lock.json
+++ b/service-quotas/cloud-formation/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "community-servicequotas-cloudformation",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/service-quotas/cloud-formation/package.json
+++ b/service-quotas/cloud-formation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "community-servicequotas-cloudformation",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "description": "AWS custom resource provider named Community::ServiceQuotas::CloudFormation.",
     "private": true,
     "main": "dist/handlers.js",

--- a/service-quotas/cloud-formation/resource-role.yaml
+++ b/service-quotas/cloud-formation/resource-role.yaml
@@ -15,7 +15,14 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
-      Path: "/"
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/Community-ServiceQuotas-CloudFormation/*
+      Path: "/community-types/"
       Policies:
         - PolicyName: ResourceTypePolicy
           PolicyDocument:

--- a/service-quotas/cloud-formation/src/models.ts
+++ b/service-quotas/cloud-formation/src/models.ts
@@ -49,3 +49,10 @@ export class ResourceModel extends BaseModel {
     }
 }
 
+export class TypeConfigurationModel extends BaseModel {
+    ['constructor']: typeof TypeConfigurationModel;
+
+
+
+}
+

--- a/service-quotas/cloud-formation/template.yml
+++ b/service-quotas/cloud-formation/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/service-quotas/dynamodb/.rpdk-config
+++ b/service-quotas/dynamodb/.rpdk-config
@@ -1,7 +1,7 @@
 {
     "typeName": "Community::ServiceQuotas::DynamoDB",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "artifact_type": "RESOURCE",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",

--- a/service-quotas/dynamodb/template.yml
+++ b/service-quotas/dynamodb/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/service-quotas/iam/.rpdk-config
+++ b/service-quotas/iam/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "Community::ServiceQuotas::IAM",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {

--- a/service-quotas/iam/template.yml
+++ b/service-quotas/iam/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/service-quotas/s3/.rpdk-config
+++ b/service-quotas/s3/.rpdk-config
@@ -1,11 +1,11 @@
 {
     "typeName": "Community::ServiceQuotas::S3",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {
-        "useDocker": true,
+        "useDocker": false,
         "protocolVersion": "2.0.0"
     }
 }

--- a/service-quotas/s3/package-lock.json
+++ b/service-quotas/s3/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "community-servicequotas-s3",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/service-quotas/s3/package.json
+++ b/service-quotas/s3/package.json
@@ -1,6 +1,6 @@
 {
     "name": "community-servicequotas-s3",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "description": "AWS custom resource provider named Community::ServiceQuotas::S3.",
     "private": true,
     "main": "dist/handlers.js",

--- a/service-quotas/s3/resource-role.yaml
+++ b/service-quotas/s3/resource-role.yaml
@@ -15,7 +15,14 @@ Resources:
             Principal:
               Service: resources.cloudformation.amazonaws.com
             Action: sts:AssumeRole
-      Path: "/"
+            Condition:
+              StringEquals:
+                aws:SourceAccount:
+                  Ref: AWS::AccountId
+              StringLike:
+                aws:SourceArn:
+                  Fn::Sub: arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/resource/Community-ServiceQuotas-S3/*
+      Path: "/community-types/"
       Policies:
         - PolicyName: ResourceTypePolicy
           PolicyDocument:

--- a/service-quotas/s3/src/models.ts
+++ b/service-quotas/s3/src/models.ts
@@ -49,3 +49,10 @@ export class ResourceModel extends BaseModel {
     }
 }
 
+export class TypeConfigurationModel extends BaseModel {
+    ['constructor']: typeof TypeConfigurationModel;
+
+
+
+}
+

--- a/service-quotas/s3/template.yml
+++ b/service-quotas/s3/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/ssm/public-access-block/.rpdk-config
+++ b/ssm/public-access-block/.rpdk-config
@@ -2,7 +2,7 @@
     "artifact_type": "RESOURCE",
     "typeName": "Community::SSM::PublicAccessBlock",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {

--- a/ssm/public-access-block/build.toml
+++ b/ssm/public-access-block/build.toml
@@ -3,7 +3,7 @@
 [function_build_definitions]
 [function_build_definitions.f772bbfe-a8e3-4c68-9e23-563cb6485c30]
 codeuri = "./"
-runtime = "nodejs14.x"
+runtime = "nodejs20.x"
 source_md5 = ""
 packagetype = "Zip"
 functions = ["TestEntrypoint", "TypeFunction"]

--- a/ssm/public-access-block/template.yml
+++ b/ssm/public-access-block/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/sso/assignment-group/.rpdk-config
+++ b/sso/assignment-group/.rpdk-config
@@ -1,7 +1,7 @@
 {
     "typeName": "Community::SSO::AssignmentGroup",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",
     "settings": {

--- a/sso/assignment-group/template.yml
+++ b/sso/assignment-group/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 

--- a/support/support-level/.rpdk-config
+++ b/support/support-level/.rpdk-config
@@ -1,7 +1,7 @@
 {
     "typeName": "Community::Support::SupportLevel",
     "language": "typescript",
-    "runtime": "nodejs14.x",
+    "runtime": "nodejs20.x",
     "artifact_type": "RESOURCE",
     "entrypoint": "dist/handlers.entrypoint",
     "testEntrypoint": "dist/handlers.testEntrypoint",

--- a/support/support-level/template.yml
+++ b/support/support-level/template.yml
@@ -12,13 +12,13 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.testEntrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 
   TypeFunction:
     Type: AWS::Serverless::Function
     Properties:
       Handler: dist/handlers.entrypoint
-      Runtime: nodejs14.x
+      Runtime: nodejs20.x
       CodeUri: ./
 


### PR DESCRIPTION
this PR ensures all resource providers:
- run on nodejs20
- are packaged with the `aws-sdk` dependency
- have a 1.0.0 version published